### PR TITLE
💚(circle) trigger release only on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,6 +459,6 @@ workflows:
             - package
           filters:
             branches:
-              only: main
+              ignore: /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
     image: "${MORK_IMAGE_NAME:-mork}:${MORK_IMAGE_TAG:-development}"
     env_file:
       - .env
-    environment:
-      PYLINTHOME: /app/.pylint.d
     ports:
       - "${MORK_SERVER_PORT:-8100}:${MORK_SERVER_PORT:-8100}"
     command:

--- a/src/mork/conf.py
+++ b/src/mork/conf.py
@@ -41,7 +41,6 @@ class Settings(BaseSettings):
     SENTRY_API_TRACES_SAMPLE_RATE: float = 1.0
     SENTRY_IGNORE_HEALTH_CHECKS: bool = False
 
-    # pylint: disable=invalid-name
     @property
     def SERVER_URL(self) -> str:
         """Get the full server URL."""


### PR DESCRIPTION
## Purpose

- Release workflow was triggered on tags and on changes on the `main` branch. Changing it so it is triggered only on tags.
- Pylint is not used in Mork, removing remaining parts of config and escapes from the project.

