### PR TITLE
🐛(api) fix fastapi dependency following 0.112.0 breaking change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ keywords = ["FastAPI", "Celery", "emails", "Open edX"]
 dependencies = [
     "celery[redis]==5.4.0",
     "pydantic_settings==2.4.0",
-    "fastapi==0.112.0",
+    "fastapi[standard]==0.112.0",
     "sentry-sdk==2.12.0",
     "SQLAlchemy==2.0.31", 
 ]


### PR DESCRIPTION
## Purpose

Before 0.112.0, fastapi would include the standard dependencies such as Uvicorn.
Now it does not include those anymore unless installed with `fastapi[standard]`.
