### PR TITLE
🧐(project) add method to retrieve inactive user count from edx database

### DIFF
--- a/.github/ISSUE_TEMPLATE/Support_question.md
+++ b/.github/ISSUE_TEMPLATE/Support_question.md
@@ -10,9 +10,9 @@ We primarily use GitHub as an issue tracker. If however you're encountering an i
 
 ---
 
-Please make sure you have read our [main Readme](https://github.com/openfun/ralph) as well as our [documentation folder](https://github.com/openfun/ralph/tree/master/docs).
+Please make sure you have read our [main Readme](https://github.com/openfun/mork) as well as our [documentation folder](https://github.com/openfun/mork/tree/main/docs).
 
-Also make sure it was not already answered in [an open or close issue](https://github.com/openfun/ralph/issues).
+Also make sure it was not already answered in [an open or close issue](https://github.com/openfun/mork/issues).
 
 If your question was not covered, and you feel like it should be, fire away! We'd love to improve our docs! 👌
 

--- a/src/mork/edx/database.py
+++ b/src/mork/edx/database.py
@@ -1,4 +1,4 @@
-"""Mork database connection."""
+"""Mork edx database connection."""
 
 import logging
 

--- a/src/mork/edx/models.py
+++ b/src/mork/edx/models.py
@@ -1,4 +1,4 @@
-"""Mork models."""
+"""Mork edx models."""
 
 import datetime
 from typing import Optional

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,4 +5,4 @@
 from .fixtures.app import http_client
 from .fixtures.asynchronous import anyio_backend
 from .fixtures.auth import auth_headers
-from .fixtures.db import db
+from .fixtures.db import edx_db

--- a/tests/edx/test_mixins.py
+++ b/tests/edx/test_mixins.py
@@ -1,6 +1,6 @@
 """Tests of the mixins class."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from faker import Faker
 
@@ -8,58 +8,8 @@ from mork.edx.factories import EdxUserFactory
 from mork.edx.models import User
 
 
-def test_edx_usermixin_get_inactives(db):
-    """Test the `get_inactives` method."""
-    # 3 users that did not log in for 3 years
-    inactive_users = EdxUserFactory.create_batch(
-        3, last_login=Faker().date_time_between(end_date="-3y")
-    )
-    # 4 users that logged in recently
-    EdxUserFactory.create_batch(
-        4, last_login=Faker().date_time_between(start_date="-3y")
-    )
-
-    # Get all users inactive for more than 3 years
-    users = User.get_inactives(
-        db.session, inactivity_period=timedelta(days=365 * 3), offset=0, limit=9
-    )
-
-    assert len(users) == 3
-    assert users == inactive_users
-
-
-def test_edx_usermixin_get_inactives_empty(db):
-    """Test the `get_inactives` method with no inactive users."""
-
-    users = User.get_inactives(
-        db.session, inactivity_period=timedelta(days=365 * 3), offset=0, limit=9
-    )
-
-    assert users == []
-
-
-def test_edx_usermixin_get_inactives_slice(db):
-    """Test the `get_inactives` method with a slice."""
-    # 3 users that did not log in for 3 years
-    inactive_users = EdxUserFactory.create_batch(
-        3, last_login=Faker().date_time_between(end_date="-3y")
-    )
-    # 4 users that logged in recently
-    EdxUserFactory.create_batch(
-        4, last_login=Faker().date_time_between(start_date="-3y")
-    )
-
-    # Get two users inactive for more than 3 years
-    users = User.get_inactives(
-        db.session, inactivity_period=timedelta(days=365 * 3), offset=0, limit=2
-    )
-
-    assert len(users) == 2
-    assert users == inactive_users[:2]
-
-
-def test_edx_usermixin_get_inactives_slice_empty(db):
-    """Test the `get_inactives` method with an empty slice ."""
+def test_edx_usermixin_get_inactive_users_count(edx_db):
+    """Test the `get_inactive_users_count` method."""
     # 3 users that did not log in for 3 years
     EdxUserFactory.create_batch(3, last_login=Faker().date_time_between(end_date="-3y"))
     # 4 users that logged in recently
@@ -67,8 +17,86 @@ def test_edx_usermixin_get_inactives_slice_empty(db):
         4, last_login=Faker().date_time_between(start_date="-3y")
     )
 
-    users = User.get_inactives(
-        db.session, inactivity_period=timedelta(days=365 * 3), offset=4, limit=9
+    threshold_date = datetime.now() - timedelta(days=365 * 3)
+
+    # Get count of users inactive for more than 3 years
+    users_count = User.get_inactive_users_count(edx_db.session, threshold_date)
+
+    assert users_count == 3
+
+
+def test_edx_usermixin_get_inactive_users_count_empty(edx_db):
+    """Test the `get_inactive_users_count` method with no inactive users."""
+    threshold_date = datetime.now() - timedelta(days=365 * 3)
+
+    # Get count of users inactive for more than 3 years
+    users_count = User.get_inactive_users_count(edx_db.session, threshold_date)
+
+    assert users_count == 0
+
+
+def test_edx_usermixin_get_inactive_users(edx_db):
+    """Test the `get_inactive_users` method."""
+
+    # 3 users that did not log in for 3 years
+    inactive_users = EdxUserFactory.create_batch(
+        3, last_login=Faker().date_time_between(end_date="-3y")
     )
+    # 4 users that logged in recently
+    EdxUserFactory.create_batch(
+        4, last_login=Faker().date_time_between(start_date="-3y")
+    )
+
+    threshold_date = datetime.now() - timedelta(days=365 * 3)
+
+    # Get all users inactive for more than 3 years
+    users = User.get_inactive_users(edx_db.session, threshold_date, offset=0, limit=9)
+
+    assert len(users) == 3
+    assert users == inactive_users
+
+
+def test_edx_usermixin_get_inactive_users_empty(edx_db):
+    """Test the `get_inactive_users` method with no inactive users."""
+
+    threshold_date = datetime.now() - timedelta(days=365 * 3)
+
+    users = User.get_inactive_users(edx_db.session, threshold_date, offset=0, limit=9)
+
+    assert users == []
+
+
+def test_edx_usermixin_get_inactive_users_slice(edx_db):
+    """Test the `get_inactive_users` method with a slice."""
+    # 3 users that did not log in for 3 years
+    inactive_users = EdxUserFactory.create_batch(
+        3, last_login=Faker().date_time_between(end_date="-3y")
+    )
+    # 4 users that logged in recently
+    EdxUserFactory.create_batch(
+        4, last_login=Faker().date_time_between(start_date="-3y")
+    )
+
+    threshold_date = datetime.now() - timedelta(days=365 * 3)
+
+    # Get two users inactive for more than 3 years
+    users = User.get_inactive_users(edx_db.session, threshold_date, offset=0, limit=2)
+
+    assert len(users) == 2
+    assert users == inactive_users[:2]
+
+
+def test_edx_usermixin_get_inactive_users_slice_empty(edx_db):
+    """Test the `get_inactive_users` method with an empty slice ."""
+    # 3 users that did not log in for 3 years
+    EdxUserFactory.create_batch(3, last_login=Faker().date_time_between(end_date="-3y"))
+    # 4 users that logged in recently
+    EdxUserFactory.create_batch(
+        4, last_login=Faker().date_time_between(start_date="-3y")
+    )
+
+    threshold_date = datetime.now() - timedelta(days=365 * 3)
+
+    users = User.get_inactive_users(edx_db.session, threshold_date, offset=4, limit=9)
 
     assert users == []

--- a/tests/edx/test_models.py
+++ b/tests/edx/test_models.py
@@ -3,7 +3,7 @@
 from mork.edx.factories import EdxUserFactory
 
 
-def test_edx_models_user_safe_dict(db):
+def test_edx_models_user_safe_dict(edx_db):
     """Test the `safe_dict` method for the User model."""
     edx_user = EdxUserFactory()
 

--- a/tests/fixtures/db.py
+++ b/tests/fixtures/db.py
@@ -8,7 +8,7 @@ from mork.edx.models import Base
 
 
 @pytest.fixture
-def db():
+def edx_db():
     """"""
     db = OpenEdxDB(engine, session)
     Base.metadata.create_all(engine)


### PR DESCRIPTION
## Purpose

To be able to warn/delete inactive users by batch, add a method to get the inactive users count.
As we now have multiple queries for getting inactive users informations, we should not compute the threshold date inside the query helpers, but we should compute it before and pass the threshold date to query helpers.

On a side note, fixing typo inside GitHub template
