### PR TITLE
⬇️(project) downgrade psycopg driver to psycopg2

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -8,7 +8,7 @@ MORK_API_KEYS=["APIKeyToBeChangedInProduction"]
 MORK_WARNING_PERIOD=P3Y
 
 # Mork database
-MORK_DB_ENGINE=postgresql+psycopg
+MORK_DB_ENGINE=postgresql+psycopg2
 MORK_DB_HOST=postgresql
 MORK_DB_NAME=mork-db
 MORK_DB_USER=fun

--- a/src/app/mork/conf.py
+++ b/src/app/mork/conf.py
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
     STATIC_PATH: Path = ROOT_PATH / "static"
 
     # Mork database
-    DB_ENGINE: str = "postgresql+psycopg"
+    DB_ENGINE: str = "postgresql+psycopg2"
     DB_HOST: str = "postgresql"
     DB_NAME: str = "mork-db"
     DB_USER: str = "fun"

--- a/src/app/pyproject.toml
+++ b/src/app/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "celery[redis]==5.4.0",
     "Jinja2==3.1.4",
     "jinja2-simple-tags==0.6.1",
-    "psycopg[binary]==3.2.2",
+    "psycopg2-binary==2.9.9",
     "pydantic_settings==2.5.2",
     "python-datauri==2.2.0",
     "fastapi[standard]==0.115.0",


### PR DESCRIPTION
# Purpose

An issue was encountered when deploying and connecting to our PostgreSQL databases with psycopg (version 3): https://github.com/psycopg/psycopg/issues/813

# Proposal

We could have changed the encoding in the URL, but I think we should stick to psycopg2 for now.
