### PR TITLE
🩺(api) add heartbeat healthcheck

### DIFF
--- a/src/app/mork/api/routes/health.py
+++ b/src/app/mork/api/routes/health.py
@@ -1,12 +1,37 @@
 """API routes related to application health checking."""
 
 import logging
+from enum import Enum
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Response, status
+from pydantic import BaseModel
+
+from mork.database import is_alive as is_db_alive
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+class DatabaseStatus(Enum):
+    """Data backend statuses."""
+
+    OK = "ok"
+    AWAY = "away"
+    ERROR = "error"
+
+
+class Heartbeat(BaseModel):
+    """Warren backends status."""
+
+    database: DatabaseStatus
+
+    @property
+    def is_alive(self):
+        """A helper that checks the overall status."""
+        if self.database == DatabaseStatus.OK:
+            return True
+        return False
 
 
 @router.get("/__lbheartbeat__")
@@ -16,3 +41,17 @@ async def lbheartbeat() -> None:
     Return a 200 when the server is running.
     """
     return
+
+
+@router.get("/__heartbeat__", status_code=status.HTTP_200_OK)
+async def heartbeat(response: Response) -> Heartbeat:
+    """Application heartbeat.
+
+    Return a 200 if all checks are successful.
+    """
+    statuses = Heartbeat(
+        database=DatabaseStatus.OK if is_db_alive() else DatabaseStatus.ERROR,
+    )
+    if not statuses.is_alive:
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+    return statuses

--- a/src/app/mork/database.py
+++ b/src/app/mork/database.py
@@ -1,9 +1,14 @@
 """Mork database connection."""
 
 import logging
+from threading import Lock
+from typing import Generator, Optional
 
-from sqlalchemy import NullPool, create_engine
-from sqlalchemy.orm import Session
+from pydantic import PostgresDsn
+from sqlalchemy import Engine as SAEngine
+from sqlalchemy import NullPool, create_engine, text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session as SASession
 
 from mork.conf import settings
 
@@ -11,7 +16,10 @@ logger = logging.getLogger(__name__)
 
 
 class MorkDB:
-    """Class to connect to the Mork database."""
+    """Class to connect to the Mork database.
+
+    This class is used by Celery workers to start a new engine and session per process.
+    """
 
     session = None
 
@@ -22,4 +30,54 @@ class MorkDB:
         self.engine = create_engine(
             settings.DB_URL, echo=settings.DB_DEBUG, poolclass=NullPool
         )
-        self.session = Session(self.engine)
+        self.session = SASession(self.engine)
+
+
+class Singleton(type):
+    """Thread-safe singleton pattern metaclass."""
+
+    _instances: dict = {}
+    _lock: Lock = Lock()
+
+    def __call__(cls, *args, **kwargs):
+        """Store instances in a private class property."""
+        if cls not in cls._instances:
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+class Engine(metaclass=Singleton):
+    """Database engine singleton used by the API to connect to the Mork database."""
+
+    _engine: Optional[SAEngine] = None
+
+    def get_engine(self, url: PostgresDsn, echo: bool = False) -> SAEngine:
+        """Get created engine or create a new one."""
+        if self._engine is None:
+            logger.debug("Create a new engine")
+            self._engine = create_engine(str(url), echo=echo)
+        logger.debug("Getting database engine %s", self._engine)
+        return self._engine
+
+
+def get_engine() -> SAEngine:
+    """Get database engine."""
+    return Engine().get_engine(url=settings.DB_URL, echo=settings.DB_DEBUG)
+
+
+def get_session() -> Generator[SASession, None, None]:
+    """Get database session."""
+    with SASession(bind=get_engine()) as session:
+        logger.debug("Getting session %s", session)
+        yield session
+
+
+def is_alive() -> bool:
+    """Check if database connection is alive."""
+    session = next(get_session())
+    try:
+        session.execute(text("SELECT 1 as is_alive"))
+        return True
+    except OperationalError as err:
+        logger.debug("Exception: %s", err)
+        return False

--- a/src/app/mork/tests/test_database.py
+++ b/src/app/mork/tests/test_database.py
@@ -1,0 +1,13 @@
+"""Tests for Mork database module."""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+
+
+def test_database_connection(db_session):
+    """Test the PostgreSQL database connection."""
+    try:
+        db_session.execute(text("SELECT 42 as life"))
+    except OperationalError:
+        pytest.fail("Cannot connect to configured database")

--- a/src/app/pyproject.toml
+++ b/src/app/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "Jinja2==3.1.4",
     "jinja2-simple-tags==0.6.1",
     "psycopg2-binary==2.9.9",
+    "pydantic==2.9.2",
     "pydantic_settings==2.5.2",
     "python-datauri==2.2.0",
     "pymysql==1.1.1",


### PR DESCRIPTION
## Purpose

A health endpoint for Kubernetes readiness probe is missing.

## Proposal

- [x] integrate postgresql database support from the api
We already have a class used by Celery workers to connect to the PostgreSQL database but it is not ideal for connecting from the API (no connection pool used, one session per transaction).
Adding a singleton pattern for creating a single engine along with a session generator, to share a single connection pool throughout the API's lifespan.

- [x] add heartbeat healthcheck

