### PR TITLE
✨(app) add missing sqlalchemy models for edx tables with personal data

### DIFF
--- a/src/app/mork/edx/factories/bulk.py
+++ b/src/app/mork/edx/factories/bulk.py
@@ -1,4 +1,4 @@
-"""Factory classes for generating fake data for testing."""
+"""Factory classes for bulk models."""
 
 import factory
 

--- a/src/app/mork/edx/factories/certificates.py
+++ b/src/app/mork/edx/factories/certificates.py
@@ -1,4 +1,4 @@
-"""Factory classes for generating fake data for testing."""
+"""Factory classes for certificates models."""
 
 import factory
 

--- a/src/app/mork/edx/factories/contentstore.py
+++ b/src/app/mork/edx/factories/contentstore.py
@@ -1,4 +1,4 @@
-"""Factory classes for generating fake data for testing."""
+"""Factory classes for contentstore models."""
 
 import factory
 

--- a/src/app/mork/edx/factories/course.py
+++ b/src/app/mork/edx/factories/course.py
@@ -1,10 +1,12 @@
-"""Factory classes for generating fake data for testing."""
+"""Factory classes for course models."""
 
 import factory
 
 from mork.edx.models.course import (
     CourseActionStateCoursererunstate,
     CourseCreatorsCoursecreator,
+    CourseGroupsCohortmembership,
+    CourseGroupsCourseusergroupUsers,
 )
 
 from .base import faker, session
@@ -47,3 +49,34 @@ class EdxCourseCreatorsCoursecreatorFactory(factory.alchemy.SQLAlchemyModelFacto
     state_changed = factory.Faker("date_time")
     state = factory.Faker("word")
     note = factory.Faker("text")
+
+
+class EdxCourseGroupsCourseusergroupUsersFactory(
+    factory.alchemy.SQLAlchemyModelFactory
+):
+    """Factory for the `course_groups_courseusergroup_users` table."""
+
+    class Meta:
+        """Factory configuration."""
+
+        model = CourseGroupsCourseusergroupUsers
+        sqlalchemy_session = session
+
+    id = factory.Sequence(lambda n: n + 1)
+    courseusergroup_id = factory.Sequence(lambda n: n + 1)
+    user_id = factory.Sequence(lambda n: n + 1)
+
+
+class EdxCourseGroupsCohortmembershipFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Factory for the `course_groups_cohortmembership` table."""
+
+    class Meta:
+        """Factory configuration."""
+
+        model = CourseGroupsCohortmembership
+        sqlalchemy_session = session
+
+    id = factory.Sequence(lambda n: n + 1)
+    course_user_group_id = factory.Sequence(lambda n: n + 1)
+    user_id = factory.Sequence(lambda n: n + 1)
+    course_id = factory.Sequence(lambda n: f"course-v1:edX+{faker.pystr()}+{n}")

--- a/src/app/mork/edx/factories/courseware.py
+++ b/src/app/mork/edx/factories/courseware.py
@@ -1,10 +1,11 @@
-"""Factory classes for generating fake data for testing."""
+"""Factory classes for courseware models."""
 
 import factory
 
 from mork.edx.models.courseware import (
     CoursewareOfflinecomputedgrade,
     CoursewareStudentmodule,
+    CoursewareStudentmodulehistory,
     CoursewareXmodulestudentinfofield,
     CoursewareXmodulestudentprefsfield,
 )
@@ -29,6 +30,23 @@ class EdxCoursewareOfflinecomputedgradeFactory(factory.alchemy.SQLAlchemyModelFa
     gradeset = factory.Faker("json")
 
 
+class EdxCoursewareStudentmodulehistoryFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Factory for the `courseware_studentmodulehistory` table."""
+
+    class Meta:
+        """Factory configuration."""
+
+        model = CoursewareStudentmodulehistory
+        sqlalchemy_session = session
+
+    id = factory.Sequence(lambda n: n + 1)
+    version = factory.Faker("pystr")
+    created = factory.Faker("date_time")
+    state = factory.Faker("json")
+    grade = factory.Faker("pyfloat")
+    max_grade = factory.Faker("pyfloat")
+
+
 class EdxCoursewareStudentmoduleFactory(factory.alchemy.SQLAlchemyModelFactory):
     """Factory for the `courseware_studentmodule` table."""
 
@@ -51,6 +69,13 @@ class EdxCoursewareStudentmoduleFactory(factory.alchemy.SQLAlchemyModelFactory):
     max_grade = factory.Faker("pyfloat")
     done = factory.Faker("pystr", max_chars=8)
     course_id = factory.Sequence(lambda n: f"course-v1:edX+{faker.pystr()}+{n}")
+
+    courseware_studentmodulehistory = factory.RelatedFactoryList(
+        EdxCoursewareStudentmodulehistoryFactory,
+        "student_module",
+        size=3,
+        student_module_id=factory.SelfAttribute("..id"),
+    )
 
 
 class EdxCoursewareXmodulestudentinfofieldFactory(

--- a/src/app/mork/edx/factories/dark.py
+++ b/src/app/mork/edx/factories/dark.py
@@ -1,4 +1,4 @@
-"""Factory classes for generating fake data for testing."""
+"""Factory classes for dark models."""
 
 import factory
 

--- a/src/app/mork/edx/factories/django.py
+++ b/src/app/mork/edx/factories/django.py
@@ -1,0 +1,21 @@
+"""Factory classes for django models."""
+
+import factory
+
+from mork.edx.models.django import DjangoCommentClientRoleUsers
+
+from .base import session
+
+
+class EdxDjangoCommentClientRoleUsersFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Factory for the `django_comment_client_role_users` table."""
+
+    class Meta:
+        """Factory configuration."""
+
+        model = DjangoCommentClientRoleUsers
+        sqlalchemy_session = session
+
+    id = factory.Sequence(lambda n: n + 1)
+    role_id = factory.Sequence(lambda n: n + 1)
+    user_id = factory.Sequence(lambda n: n + 1)

--- a/src/app/mork/edx/factories/instructor.py
+++ b/src/app/mork/edx/factories/instructor.py
@@ -1,4 +1,4 @@
-"""Factory classes for generating fake data for testing."""
+"""Factory classes for instructor models."""
 
 import factory
 

--- a/src/app/mork/edx/factories/notify.py
+++ b/src/app/mork/edx/factories/notify.py
@@ -1,4 +1,4 @@
-"""Factory classes for generating fake data for testing."""
+"""Factory classes for notify models."""
 
 import factory
 

--- a/src/app/mork/edx/factories/payment.py
+++ b/src/app/mork/edx/factories/payment.py
@@ -1,0 +1,22 @@
+"""Factory classes for payment models."""
+
+import factory
+
+from mork.edx.models.payment import PaymentUseracceptance
+
+from .base import session
+
+
+class EdxPaymentUseracceptanceFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Factory for the `payment_useracceptance` table."""
+
+    class Meta:
+        """Factory configuration."""
+
+        model = PaymentUseracceptance
+        sqlalchemy_session = session
+
+    id = factory.Sequence(lambda n: n + 1)
+    user_id = factory.Sequence(lambda n: n + 1)
+    terms_id = factory.Sequence(lambda n: n + 1)
+    datetime = factory.Faker("date_time")

--- a/src/app/mork/edx/factories/proctoru.py
+++ b/src/app/mork/edx/factories/proctoru.py
@@ -1,4 +1,4 @@
-"""Factory classes for generating fake data for testing."""
+"""Factory classes for proctoru models."""
 
 import factory
 
@@ -8,7 +8,7 @@ from .base import session
 
 
 class EdxProctoruProctoruexamFactory(factory.alchemy.SQLAlchemyModelFactory):
-    """Model for the `proctoru_proctoruexam` table."""
+    """Factory for the `proctoru_proctoruexam` table."""
 
     class Meta:
         """Factory configuration."""
@@ -31,7 +31,7 @@ class EdxProctoruProctoruexamFactory(factory.alchemy.SQLAlchemyModelFactory):
 
 
 class EdxProctoruProctoruuserFactory(factory.alchemy.SQLAlchemyModelFactory):
-    """Model for the `proctoru_proctoruuser` table."""
+    """Factory for the `proctoru_proctoruuser` table."""
 
     class Meta:
         """Factory configuration."""

--- a/src/app/mork/edx/factories/student.py
+++ b/src/app/mork/edx/factories/student.py
@@ -1,4 +1,4 @@
-"""Factory classes for generating fake data for testing."""
+"""Factory classes for student models."""
 
 import factory
 
@@ -6,8 +6,12 @@ from mork.edx.models.student import (
     StudentAnonymoususerid,
     StudentCourseaccessrole,
     StudentCourseenrollment,
+    StudentCourseenrollmentallowed,
+    StudentCourseenrollmentattribute,
     StudentHistoricalcourseenrollment,
+    StudentLanguageproficiency,
     StudentLoginfailure,
+    StudentManualenrollmentaudit,
     StudentPendingemailchange,
     StudentUserstanding,
 )
@@ -46,20 +50,38 @@ class EdxStudentCourseaccessroleFactory(factory.alchemy.SQLAlchemyModelFactory):
     role = factory.Faker("word")
 
 
-class EdxStudentCourseEnrollmentFactory(factory.alchemy.SQLAlchemyModelFactory):
-    """Factory for generating fake Open edX enrollments."""
+class EdxStudentCourseenrollmentallowedFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Factory for the `student_courseenrollmentallowed` table."""
 
     class Meta:
         """Factory configuration."""
 
-        model = StudentCourseenrollment
+        model = StudentCourseenrollmentallowed
         sqlalchemy_session = session
 
-    user_id = factory.Sequence(lambda n: n + 1)
+    id = factory.Sequence(lambda n: n + 1)
+    email = factory.Faker("email")
     course_id = factory.Sequence(lambda n: f"course-v1:edX+{faker.pystr()}+{n}")
     created = factory.Faker("date_time")
-    is_active = True
-    mode = factory.Faker("word")
+    auto_enroll = factory.Faker("random_int", min=0, max=1)
+
+
+class EdxStudentCourseenrollmentattributeFactory(
+    factory.alchemy.SQLAlchemyModelFactory
+):
+    """Factory for the `student_courseenrollmentattribute` table."""
+
+    class Meta:
+        """Factory configuration."""
+
+        model = StudentCourseenrollmentattribute
+        sqlalchemy_session = session
+
+    id = factory.Sequence(lambda n: n + 1)
+    enrollment_id = factory.Sequence(lambda n: n + 1)
+    namespace = factory.Faker("pystr")
+    name = factory.Faker("pystr")
+    value = factory.Faker("pystr")
 
 
 class EdxStudentHistoricalcourseenrollmentFactory(
@@ -77,10 +99,26 @@ class EdxStudentHistoricalcourseenrollmentFactory(
     course_id = factory.Sequence(lambda n: f"course-v1:edX+{faker.pystr()}+{n}")
     created = factory.Faker("date_time")
     is_active = factory.Faker("random_int", min=0, max=1)
-    mode = factory.Faker("word")
+    mode = factory.Faker("pystr")
+    user_id = factory.Sequence(lambda n: n + 1)
     history_id = factory.Sequence(lambda n: n + 1)
     history_date = factory.Faker("date_time")
-    history_type = factory.Faker("random_element", elements=["+", "-", "~"])
+    history_user_id = factory.Sequence(lambda n: n + 1)
+    history_type = factory.Faker("random_letter")
+
+
+class EdxStudentLanguageproficiencyFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Factory for the `student_languageproficiency` table."""
+
+    class Meta:
+        """Factory configuration."""
+
+        model = StudentLanguageproficiency
+        sqlalchemy_session = session
+
+    id = factory.Sequence(lambda n: n + 1)
+    user_profile_id = factory.Sequence(lambda n: n + 1)
+    code = factory.Faker("pystr")
 
 
 class EdxStudentLoginfailureFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -96,6 +134,54 @@ class EdxStudentLoginfailureFactory(factory.alchemy.SQLAlchemyModelFactory):
     user_id = factory.Sequence(lambda n: n + 1)
     failure_count = factory.Sequence(lambda n: n)
     lockout_until = factory.Faker("date_time")
+
+
+class EdxStudentManualenrollmentauditFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Factory for the `student_manualenrollmentaudit` table."""
+
+    class Meta:
+        """Factory configuration."""
+
+        model = StudentManualenrollmentaudit
+        sqlalchemy_session = session
+
+    id = factory.Sequence(lambda n: n + 1)
+    enrollment_id = factory.Sequence(lambda n: n + 1)
+    enrolled_by_id = factory.Sequence(lambda n: n + 1)
+    enrolled_email = factory.Faker("email")
+    time_stamp = factory.Faker("date_time")
+    state_transition = factory.Faker("pystr")
+    reason = factory.Faker("text")
+
+
+class EdxStudentCourseenrollmentFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Factory for the `student_courseenrollment` table."""
+
+    class Meta:
+        """Factory configuration."""
+
+        model = StudentCourseenrollment
+        sqlalchemy_session = session
+
+    id = factory.Sequence(lambda n: n + 1)
+    user_id = factory.Sequence(lambda n: n + 1)
+    course_id = factory.Sequence(lambda n: f"course-v1:edX+{faker.pystr()}+{n}")
+    is_active = factory.Faker("random_int", min=0, max=1)
+    mode = factory.Faker("word")
+    created = factory.Faker("date_time")
+
+    student_courseenrollmentattribute = factory.RelatedFactoryList(
+        EdxStudentCourseenrollmentattributeFactory,
+        "enrollment",
+        size=3,
+        enrollment_id=factory.SelfAttribute("..id"),
+    )
+    student_manualenrollmentaudit = factory.RelatedFactoryList(
+        EdxStudentManualenrollmentauditFactory,
+        "enrollment",
+        size=3,
+        enrollment_id=factory.SelfAttribute("..id"),
+    )
 
 
 class EdxStudentPendingemailchangeFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -123,5 +209,7 @@ class EdxStudentUserstandingFactory(factory.alchemy.SQLAlchemyModelFactory):
         sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
+    user_id = factory.Sequence(lambda n: n + 1)
     account_status = factory.Faker("word")
+    changed_by_id = factory.Sequence(lambda n: n + 1)
     standing_last_changed_at = factory.Faker("date_time")

--- a/src/app/mork/edx/factories/user.py
+++ b/src/app/mork/edx/factories/user.py
@@ -1,4 +1,4 @@
-"""Factory classes for generating fake data for testing."""
+"""Factory classes for user models."""
 
 import factory
 

--- a/src/app/mork/edx/factories/util.py
+++ b/src/app/mork/edx/factories/util.py
@@ -1,4 +1,4 @@
-"""Factory classes for generating fake data for testing."""
+"""Factory classes for util models."""
 
 import factory
 

--- a/src/app/mork/edx/factories/verify.py
+++ b/src/app/mork/edx/factories/verify.py
@@ -1,8 +1,11 @@
-"""Factory classes for generating fake data for testing."""
+"""Factory classes for verify models."""
 
 import factory
 
-from mork.edx.models.verify import VerifyStudentHistoricalverificationdeadline
+from mork.edx.models.verify import (
+    VerifyStudentHistoricalverificationdeadline,
+    VerifyStudentSoftwaresecurephotoverification,
+)
 
 from .base import faker, session
 
@@ -10,7 +13,7 @@ from .base import faker, session
 class EdxVerifyStudentHistoricalverificationdeadlineFactory(
     factory.alchemy.SQLAlchemyModelFactory
 ):
-    """Model for the `verify_student_historicalverificationdeadline` table."""
+    """Factory for the `verify_student_historicalverificationdeadline` table."""
 
     class Meta:
         """Factory configuration."""
@@ -28,3 +31,34 @@ class EdxVerifyStudentHistoricalverificationdeadlineFactory(
     history_user_id = factory.Sequence(lambda n: n + 1)
     history_type = factory.Faker("random_element", elements=["+", "-", "~"])
     deadline_is_explicit = factory.Faker("random_int", min=0, max=1)
+
+
+class EdxVerifyStudentSoftwaresecurephotoverificationFactory(
+    factory.alchemy.SQLAlchemyModelFactory
+):
+    """Factory for the `verify_student_softwaresecurephotoverification` table."""
+
+    class Meta:
+        """Factory configuration."""
+
+        model = VerifyStudentSoftwaresecurephotoverification
+        sqlalchemy_session = session
+
+    id = factory.Sequence(lambda n: n + 1)
+    status = factory.Faker("pystr")
+    status_changed = factory.Faker("date_time")
+    user_id = factory.Sequence(lambda n: n + 1)
+    name = factory.Faker("pystr")
+    face_image_url = factory.Faker("url")
+    photo_id_image_url = factory.Faker("url")
+    receipt_id = factory.Faker("pystr")
+    created_at = factory.Faker("date_time")
+    updated_at = factory.Faker("date_time")
+    submitted_at = factory.Faker("date_time")
+    reviewing_user_id = factory.Sequence(lambda n: n + 1)
+    reviewing_service = factory.Faker("pystr")
+    error_msg = factory.Faker("text")
+    error_code = factory.Faker("pystr")
+    photo_id_key = factory.Faker("text")
+    display = factory.Faker("random_int", min=0, max=1)
+    copy_id_photo_from_id = factory.Sequence(lambda n: n + 1)

--- a/src/app/mork/edx/models/bulk.py
+++ b/src/app/mork/edx/models/bulk.py
@@ -1,4 +1,4 @@
-"""Mork edx models."""
+"""Mork edx bulk models."""
 
 import datetime
 

--- a/src/app/mork/edx/models/certificates.py
+++ b/src/app/mork/edx/models/certificates.py
@@ -1,4 +1,4 @@
-"""Mork edx models."""
+"""Mork edx certificates models."""
 
 import datetime
 

--- a/src/app/mork/edx/models/course.py
+++ b/src/app/mork/edx/models/course.py
@@ -1,4 +1,4 @@
-"""Mork edx models."""
+"""Mork edx course models."""
 
 import datetime
 
@@ -77,4 +77,56 @@ class CourseCreatorsCoursecreator(Base):
 
     user: Mapped["AuthUser"] = relationship(  # noqa: F821
         "AuthUser", back_populates="course_creators_coursecreator"
+    )
+
+
+class CourseGroupsCourseusergroupUsers(Base):
+    """Model for the `course_groups_courseusergroup_users` table."""
+
+    __tablename__ = "course_groups_courseusergroup_users"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["user_id"],
+            ["auth_user.id"],
+        ),
+        Index("courseusergroup_id", "courseusergroup_id", "user_id", unique=True),
+    )
+
+    id: Mapped[int] = mapped_column(INTEGER(11), primary_key=True)
+    courseusergroup_id: Mapped[int] = mapped_column(
+        INTEGER(11), nullable=False, index=True
+    )
+    user_id: Mapped[int] = mapped_column(INTEGER(11), nullable=False, index=True)
+
+    user: Mapped["AuthUser"] = relationship(  # noqa: F821
+        "AuthUser", back_populates="course_groups_courseusergroup_users"
+    )
+
+
+class CourseGroupsCohortmembership(Base):
+    """Model for the `course_groups_cohortmembership` table."""
+
+    __tablename__ = "course_groups_cohortmembership"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["user_id"],
+            ["auth_user.id"],
+        ),
+        Index(
+            "course_groups_cohortmembership_user_id_395bddd0389ed7da_uniq",
+            "user_id",
+            "course_id",
+            unique=True,
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(INTEGER(11), primary_key=True)
+    course_user_group_id: Mapped[int] = mapped_column(
+        INTEGER(11), nullable=False, index=True
+    )
+    user_id: Mapped[int] = mapped_column(INTEGER(11), nullable=False, index=True)
+    course_id: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    user: Mapped["AuthUser"] = relationship(  # noqa: F821
+        "AuthUser", back_populates="course_groups_cohortmembership"
     )

--- a/src/app/mork/edx/models/courseware.py
+++ b/src/app/mork/edx/models/courseware.py
@@ -1,6 +1,7 @@
-"""Mork edx models."""
+"""Mork edx courseware models."""
 
 import datetime
+from typing import List
 
 from sqlalchemy import DateTime, Float, ForeignKeyConstraint, Index, String
 from sqlalchemy.dialects.mysql import INTEGER, TEXT
@@ -77,6 +78,42 @@ class CoursewareStudentmodule(Base):
 
     student: Mapped["AuthUser"] = relationship(  # noqa: F821
         "AuthUser", back_populates="courseware_studentmodule"
+    )
+
+    courseware_studentmodulehistory: Mapped[List["CoursewareStudentmodulehistory"]] = (
+        relationship(
+            "CoursewareStudentmodulehistory",
+            back_populates="student_module",
+            cascade="all, delete-orphan",
+        )
+    )
+
+
+class CoursewareStudentmodulehistory(Base):
+    """Model for the `courseware_studentmodulehistory` table."""
+
+    __tablename__ = "courseware_studentmodulehistory"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["student_module_id"],
+            ["courseware_studentmodule.id"],
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(INTEGER(11), primary_key=True)
+    student_module_id: Mapped["CoursewareStudentmodule"] = mapped_column(
+        INTEGER(11), nullable=False, index=True
+    )
+    version: Mapped[str] = mapped_column(String(255), index=True)
+    created: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, index=True
+    )
+    state: Mapped[str] = mapped_column(TEXT)
+    grade: Mapped[float] = mapped_column(Float(asdecimal=True))
+    max_grade: Mapped[float] = mapped_column(Float(asdecimal=True))
+
+    student_module: Mapped["CoursewareStudentmodule"] = relationship(
+        "CoursewareStudentmodule", back_populates="courseware_studentmodulehistory"
     )
 
 

--- a/src/app/mork/edx/models/django.py
+++ b/src/app/mork/edx/models/django.py
@@ -1,0 +1,33 @@
+"""Mork edx django models."""
+
+from sqlalchemy import ForeignKeyConstraint, Index
+from sqlalchemy.dialects.mysql import INTEGER
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+
+class DjangoCommentClientRoleUsers(Base):
+    """Model for the `django_comment_client_role_users` table."""
+
+    __tablename__ = "django_comment_client_role_users"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["user_id"],
+            ["auth_user.id"],
+        ),
+        Index(
+            "django_comment_client_role_users_role_id_78e483f531943614_uniq",
+            "role_id",
+            "user_id",
+            unique=True,
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(INTEGER(11), primary_key=True)
+    role_id: Mapped[int] = mapped_column(INTEGER(11), nullable=False, index=True)
+    user_id: Mapped[int] = mapped_column(INTEGER(11), nullable=False, index=True)
+
+    user: Mapped["AuthUser"] = relationship(  # noqa: F821
+        "AuthUser", back_populates="django_comment_client_role_users"
+    )

--- a/src/app/mork/edx/models/instructor.py
+++ b/src/app/mork/edx/models/instructor.py
@@ -1,4 +1,4 @@
-"""Mork edx models."""
+"""Mork edx instructor models."""
 
 import datetime
 

--- a/src/app/mork/edx/models/notify.py
+++ b/src/app/mork/edx/models/notify.py
@@ -1,4 +1,4 @@
-"""Mork edx models."""
+"""Mork edx notify models."""
 
 from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy.dialects.mysql import INTEGER

--- a/src/app/mork/edx/models/payment.py
+++ b/src/app/mork/edx/models/payment.py
@@ -12,7 +12,7 @@ from .base import Base
 class PaymentUseracceptance(Base):
     """Model for the `payment_useracceptance` table."""
 
-    __tablename__ = "c"
+    __tablename__ = "payment_useracceptance"
     __table_args__ = (
         ForeignKeyConstraint(
             ["user_id"],

--- a/src/app/mork/edx/models/payment.py
+++ b/src/app/mork/edx/models/payment.py
@@ -1,0 +1,36 @@
+"""Mork edx payment models."""
+
+import datetime as dt
+
+from sqlalchemy import DateTime, ForeignKeyConstraint, Index
+from sqlalchemy.dialects.mysql import INTEGER
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+
+class PaymentUseracceptance(Base):
+    """Model for the `payment_useracceptance` table."""
+
+    __tablename__ = "c"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["user_id"],
+            ["auth_user.id"],
+        ),
+        Index(
+            "payment_useracceptance_user_id_743f016c85c1493e_uniq",
+            "user_id",
+            "terms_id",
+            unique=True,
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(INTEGER(11), primary_key=True)
+    user_id: Mapped[int] = mapped_column(INTEGER(11), nullable=False, index=True)
+    terms_id: Mapped[int] = mapped_column(INTEGER(11), nullable=False, index=True)
+    datetime: Mapped[dt.datetime] = mapped_column(DateTime, nullable=False, index=True)
+
+    user: Mapped["AuthUser"] = relationship(  # noqa: F821
+        "AuthUser", back_populates="payment_useracceptance"
+    )

--- a/src/app/mork/edx/models/proctoru.py
+++ b/src/app/mork/edx/models/proctoru.py
@@ -1,4 +1,4 @@
-"""Mork edx models."""
+"""Mork edx proctoru models."""
 
 import datetime
 

--- a/src/app/mork/edx/models/user.py
+++ b/src/app/mork/edx/models/user.py
@@ -1,4 +1,4 @@
-"""Mork edx models."""
+"""Mork edx user models."""
 
 from sqlalchemy import ForeignKeyConstraint, Index, String
 from sqlalchemy.dialects.mysql import INTEGER, TEXT

--- a/src/app/mork/edx/models/verify.py
+++ b/src/app/mork/edx/models/verify.py
@@ -1,9 +1,9 @@
-"""Mork edx models."""
+"""Mork edx verify models."""
 
 import datetime
 
 from sqlalchemy import DateTime, ForeignKeyConstraint, String
-from sqlalchemy.dialects.mysql import INTEGER
+from sqlalchemy.dialects.mysql import INTEGER, TEXT
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import Base
@@ -32,4 +32,54 @@ class VerifyStudentHistoricalverificationdeadline(Base):
 
     history_user: Mapped["AuthUser"] = relationship(  # noqa: F821
         "AuthUser", back_populates="verify_student_historicalverificationdeadline"
+    )
+
+
+class VerifyStudentSoftwaresecurephotoverification(Base):
+    """Model for the `verify_student_softwaresecurephotoverification` table."""
+
+    __tablename__ = "verify_student_softwaresecurephotoverification"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["user_id"],
+            ["auth_user.id"],
+        ),
+        ForeignKeyConstraint(
+            ["reviewing_user_id"],
+            ["auth_user.id"],
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(INTEGER(11), primary_key=True)
+    status: Mapped[str] = mapped_column(String(100), nullable=False)
+    status_changed: Mapped[datetime.datetime] = mapped_column(DateTime, nullable=False)
+    user_id: Mapped[int] = mapped_column(INTEGER(11), nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    face_image_url: Mapped[str] = mapped_column(String(255), nullable=False)
+    photo_id_image_url: Mapped[str] = mapped_column(String(255), nullable=False)
+    receipt_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, index=True
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, index=True
+    )
+    submitted_at: Mapped[datetime.datetime] = mapped_column(DateTime, index=True)
+    reviewing_user_id: Mapped[int] = mapped_column(INTEGER(11), index=True)
+    reviewing_service: Mapped[str] = mapped_column(String(255), nullable=False)
+    error_msg: Mapped[str] = mapped_column(TEXT, nullable=False)
+    error_code: Mapped[str] = mapped_column(String(50), nullable=False)
+    photo_id_key: Mapped[str] = mapped_column(TEXT, nullable=False)
+    display: Mapped[int] = mapped_column(INTEGER(1), nullable=False, index=True)
+    copy_id_photo_from_id: Mapped[int] = mapped_column(INTEGER(11), index=True)
+
+    reviewing_user: Mapped["AuthUser"] = relationship(  # noqa: F821
+        "AuthUser",
+        primaryjoin="VerifyStudentSoftwaresecurephotoverification.reviewing_user_id == AuthUser.id",  # noqa: E501
+        back_populates="verify_student_softwaresecurephotoverification_reviewing_user",
+    )
+    user: Mapped["AuthUser"] = relationship(  # noqa: F821
+        "AuthUser",
+        primaryjoin="VerifyStudentSoftwaresecurephotoverification.user_id == AuthUser.id",  # noqa: E501
+        back_populates="verify_student_softwaresecurephotoverification_user",
     )

--- a/src/app/mork/tests/edx/test_mixins.py
+++ b/src/app/mork/tests/edx/test_mixins.py
@@ -11,7 +11,7 @@ from mork.edx.models.base import Base
 from mork.exceptions import UserDeleteError
 
 
-def test_edx_usermixin_get_inactive_users_count(edx_db):
+def test_edx_authusermixin_get_inactive_users_count(edx_db):
     """Test the `get_inactive_users_count` method."""
     # 3 users that did not log in for 3 years
     EdxAuthUserFactory.create_batch(
@@ -30,7 +30,7 @@ def test_edx_usermixin_get_inactive_users_count(edx_db):
     assert users_count == 3
 
 
-def test_edx_usermixin_get_inactive_users_count_empty(edx_db):
+def test_edx_authusermixin_get_inactive_users_count_empty(edx_db):
     """Test the `get_inactive_users_count` method with no inactive users."""
     threshold_date = datetime.now() - timedelta(days=365 * 3)
 
@@ -40,7 +40,7 @@ def test_edx_usermixin_get_inactive_users_count_empty(edx_db):
     assert users_count == 0
 
 
-def test_edx_usermixin_get_inactive_users(edx_db):
+def test_edx_authusermixin_get_inactive_users(edx_db):
     """Test the `get_inactive_users` method."""
 
     # 3 users that did not log in for 3 years
@@ -63,7 +63,7 @@ def test_edx_usermixin_get_inactive_users(edx_db):
     assert users == inactive_users
 
 
-def test_edx_usermixin_get_inactive_users_empty(edx_db):
+def test_edx_authusermixin_get_inactive_users_empty(edx_db):
     """Test the `get_inactive_users` method with no inactive users."""
 
     threshold_date = datetime.now() - timedelta(days=365 * 3)
@@ -75,7 +75,7 @@ def test_edx_usermixin_get_inactive_users_empty(edx_db):
     assert users == []
 
 
-def test_edx_usermixin_get_inactive_users_slice(edx_db):
+def test_edx_authusermixin_get_inactive_users_slice(edx_db):
     """Test the `get_inactive_users` method with a slice."""
     # 3 users that did not log in for 3 years
     inactive_users = EdxAuthUserFactory.create_batch(
@@ -97,7 +97,7 @@ def test_edx_usermixin_get_inactive_users_slice(edx_db):
     assert users == inactive_users[:2]
 
 
-def test_edx_usermixin_get_inactive_users_slice_empty(edx_db):
+def test_edx_authusermixin_get_inactive_users_slice_empty(edx_db):
     """Test the `get_inactive_users` method with an empty slice ."""
     # 3 users that did not log in for 3 years
     EdxAuthUserFactory.create_batch(
@@ -117,7 +117,7 @@ def test_edx_usermixin_get_inactive_users_slice_empty(edx_db):
     assert users == []
 
 
-def test_edx_usermixin__get_user_missing(edx_db):
+def test_edx_authusermixin__get_user_missing(edx_db):
     """Test the `get_user` method with missing user in the database."""
 
     user = AuthUser.get_user(
@@ -126,7 +126,7 @@ def test_edx_usermixin__get_user_missing(edx_db):
     assert user is None
 
 
-def test_edx_usermixin__get_user(edx_db):
+def test_edx_authusermixin__get_user(edx_db):
     """Test the `get_user` method."""
     email = "john_doe@example.com"
     username = "john_doe"
@@ -138,7 +138,7 @@ def test_edx_usermixin__get_user(edx_db):
     assert user.username == username
 
 
-def test_edx_usermixin__delete_user_missing(edx_db):
+def test_edx_authusermixin__delete_user_missing(edx_db):
     """Test the `delete_user` method with missing user in the database."""
 
     with pytest.raises(UserDeleteError, match="User to delete does not exist"):
@@ -147,7 +147,7 @@ def test_edx_usermixin__delete_user_missing(edx_db):
         )
 
 
-def test_edx_usermixin_delete_user(edx_db):
+def test_edx_authusermixin_delete_user(edx_db):
     """Test the `delete_user` method."""
     EdxAuthUserFactory.create_batch(
         1, email="john_doe@example.com", username="john_doe"
@@ -155,8 +155,8 @@ def test_edx_usermixin_delete_user(edx_db):
 
     # Get all related tables that have foreign key constraints on the parent table
     related_tables = [
-        "course_action_state_coursererunstate",
         "auth_userprofile",
+        "auth_user_groups",
         "authtoken_token",
         "auth_registration",
         "bulk_email_courseemail",
@@ -164,26 +164,36 @@ def test_edx_usermixin_delete_user(edx_db):
         "certificates_certificatehtmlviewconfiguration",
         "certificates_generatedcertificate",
         "contentstore_videouploadconfig",
+        "course_action_state_coursererunstate",
         "course_creators_coursecreator",
+        "course_groups_courseusergroup_users",
+        "course_groups_cohortmembership",
         "courseware_offlinecomputedgrade",
         "courseware_studentmodule",
+        "courseware_studentmodulehistory",
         "courseware_xmodulestudentinfofield",
         "courseware_xmodulestudentprefsfield",
         "dark_lang_darklangconfig",
+        "django_comment_client_role_users",
         "instructor_task_instructortask",
         "notify_settings",
+        "payment_useracceptance",
         "proctoru_proctoruexam",
         "proctoru_proctoruuser",
         "student_anonymoususerid",
         "student_courseaccessrole",
         "student_courseenrollment",
+        "student_courseenrollmentattribute",
         "student_historicalcourseenrollment",
+        "student_languageproficiency",
         "student_loginfailures",
+        "student_manualenrollmentaudit",
         "student_pendingemailchange",
         "student_userstanding",
         "user_api_userpreference",
         "util_ratelimitconfiguration",
         "verify_student_historicalverificationdeadline",
+        "verify_student_softwaresecurephotoverification",
     ]
 
     for table_name in related_tables:

--- a/src/app/mork/tests/edx/test_models.py
+++ b/src/app/mork/tests/edx/test_models.py
@@ -1,8 +1,8 @@
 """Tests of the edx models."""
 
-from mork.edx.factories.auth import EdxAuthUserFactory, EdxAuthUserProfileFactory
+from mork.edx.factories.auth import EdxAuthUserFactory, EdxAuthUserprofileFactory
 from mork.edx.factories.certificates import EdxCertificatesGeneratedCertificateFactory
-from mork.edx.factories.student import EdxStudentCourseEnrollmentFactory
+from mork.edx.factories.student import EdxStudentCourseenrollmentFactory
 from mork.edx.factories.user import EdxUserApiUserpreferenceFactory
 
 
@@ -26,8 +26,8 @@ def test_edx_models_auth_user_safe_dict(edx_db):
 
 
 def test_edx_models_auth_user_profile_safe_dict(edx_db):
-    """Test the `safe_dict` method for the AuthUserProfile model."""
-    edx_auth_user_profile = EdxAuthUserProfileFactory()
+    """Test the `safe_dict` method for the AuthUserprofile model."""
+    edx_auth_user_profile = EdxAuthUserprofileFactory()
 
     assert edx_auth_user_profile.safe_dict() == {
         "id": edx_auth_user_profile.id,
@@ -64,7 +64,7 @@ def test_edx_models_user_api_user_preference_safe_dict(edx_db):
 
 def test_edx_models_student_course_enrollment_safe_dict(edx_db):
     """Test the `safe_dict` method for the StudentCourseEnrollment model."""
-    edx_student_course_enrollment = EdxStudentCourseEnrollmentFactory()
+    edx_student_course_enrollment = EdxStudentCourseenrollmentFactory()
 
     assert edx_student_course_enrollment.safe_dict() == {
         "id": edx_student_course_enrollment.id,

--- a/src/app/mork/tests/fixtures/app.py
+++ b/src/app/mork/tests/fixtures/app.py
@@ -3,15 +3,16 @@
 from typing import AsyncIterator
 
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 from mork.api import app
 from mork.conf import settings
 
+transport = ASGITransport(app=app)
+
 
 @pytest.fixture
-@pytest.mark.anyio
 async def http_client() -> AsyncIterator[AsyncClient]:
     """Handle application lifespan while yielding asynchronous HTTP client."""
-    async with AsyncClient(app=app, base_url=settings.SERVER_URL) as client:
+    async with AsyncClient(transport=transport, base_url=settings.SERVER_URL) as client:
         yield client

--- a/src/app/pyproject.toml
+++ b/src/app/pyproject.toml
@@ -136,4 +136,4 @@ python_files = [
     "test_*.py",
     "tests.py",
 ]
-testpaths = "tests"
+testpaths = "**/tests"


### PR DESCRIPTION
## Purpose

After thorough research, additional edx tables store personal data related to users.

## Proposal

Adding these SQLAlchemy models to ensure Mork can delete the corresponding entries.
In a next step, adding corresponding factories and adding protection on tables where we must keep data (even if when a staff member is deleted).
