### PR TITLE
🔨(edx) fix mysql seeding script for development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Fixed
+
+- Fix relations in student_manualenrollmentaudit table for cascade delete
 
 ## [0.1.0] - 2024-10-22
 

--- a/bin/seed_edx_database.py
+++ b/bin/seed_edx_database.py
@@ -3,22 +3,22 @@
 import asyncio
 
 from sqlalchemy import create_engine
-from sqlalchemy.orm import Session
 
 from mork.conf import settings
 from mork.edx.factories.auth import EdxAuthUserFactory
+from mork.edx.factories.base import BaseSQLAlchemyModelFactory, Session
 from mork.edx.models.base import Base
 
 
 async def seed_edx_database():
     """Seed the MySQL edx database with mocked data."""
     engine = create_engine(settings.EDX_DB_URL)
-    session = Session(engine)
-    EdxAuthUserFactory._meta.sqlalchemy_session = session  # noqa: SLF001
-    EdxAuthUserFactory._meta.sqlalchemy_session_persistence = "commit"  # noqa: SLF001
+    Session.configure(bind=engine)
+    BaseSQLAlchemyModelFactory._meta.sqlalchemy_session = Session  # noqa: SLF001
     Base.metadata.create_all(engine)
 
-    EdxAuthUserFactory.create_batch(1000)
+    EdxAuthUserFactory.create_batch(100)
+    Session.commit()
 
 
 if __name__ == "__main__":

--- a/src/app/mork/edx/factories/auth.py
+++ b/src/app/mork/edx/factories/auth.py
@@ -10,7 +10,7 @@ from mork.edx.models.auth import (
     AuthUserprofile,
 )
 
-from .base import faker, session
+from .base import BaseSQLAlchemyModelFactory, faker
 from .bulk import EdxBulkEmailCourseemailFactory, EdxBulkEmailOptoutFactory
 from .certificates import (
     EdxCertificatesCertificatehtmlviewconfigurationFactory,
@@ -53,56 +53,52 @@ from .verify import (
 )
 
 
-class EdxAuthRegistrationFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxAuthRegistrationFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `auth_registration` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = AuthRegistration
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)
     activation_key = factory.Faker("hexify", text="^" * 32)
 
 
-class EdxAuthtokenTokenFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxAuthtokenTokenFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `authtoken_token` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = AuthtokenToken
-        sqlalchemy_session = session
 
     key = factory.Faker("hexify", text="^" * 40)
     user_id = factory.Sequence(lambda n: n + 1)
     created = factory.Faker("date_time")
 
 
-class EdxAuthUserGroupsFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxAuthUserGroupsFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `auth_user_groups` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = AuthUserGroups
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)
     group_id = factory.Sequence(lambda n: n + 1)
 
 
-class EdxAuthUserprofileFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxAuthUserprofileFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `auth_userprofile` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = AuthUserprofile
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)
@@ -130,20 +126,19 @@ class EdxAuthUserprofileFactory(factory.alchemy.SQLAlchemyModelFactory):
     )
 
 
-class EdxAuthUserFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxAuthUserFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `auth_user` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = AuthUser
-        sqlalchemy_session = session
 
     class Params:
         """Factory parameter to toggle generation of protected tables on or off."""
 
         with_protected_tables = factory.Trait(
-            authtoken_token=factory.SubFactory(
+            authtoken_token=factory.RelatedFactory(
                 EdxAuthtokenTokenFactory, user_id=factory.SelfAttribute("..id")
             ),
             certificates_certificatehtmlviewconfiguration=factory.RelatedFactoryList(
@@ -170,7 +165,7 @@ class EdxAuthUserFactory(factory.alchemy.SQLAlchemyModelFactory):
                 size=3,
                 updated_user_id=factory.SelfAttribute("..id"),
             ),
-            course_creators_coursecreator=factory.SubFactory(
+            course_creators_coursecreator=factory.RelatedFactory(
                 EdxCourseCreatorsCoursecreatorFactory,
                 user_id=factory.SelfAttribute("..id"),
             ),
@@ -206,13 +201,13 @@ class EdxAuthUserFactory(factory.alchemy.SQLAlchemyModelFactory):
     date_joined = factory.Faker("date_time")
     last_login = factory.Faker("date_time")
 
-    auth_registration = factory.SubFactory(
+    auth_registration = factory.RelatedFactory(
         EdxAuthRegistrationFactory, user_id=factory.SelfAttribute("..id")
     )
-    auth_userprofile = factory.SubFactory(
+    auth_userprofile = factory.RelatedFactory(
         EdxAuthUserprofileFactory, user_id=factory.SelfAttribute("..id")
     )
-    auth_user_groups = factory.SubFactory(
+    auth_user_groups = factory.RelatedFactory(
         EdxAuthUserGroupsFactory, user_id=factory.SelfAttribute("..id")
     )
     bulk_email_courseemail = factory.RelatedFactoryList(
@@ -299,7 +294,7 @@ class EdxAuthUserFactory(factory.alchemy.SQLAlchemyModelFactory):
         size=3,
         user_id=factory.SelfAttribute("..id"),
     )
-    proctoru_proctoruuser = factory.SubFactory(
+    proctoru_proctoruuser = factory.RelatedFactory(
         EdxProctoruProctoruuserFactory, student_id=factory.SelfAttribute("..id")
     )
     student_anonymoususerid = factory.RelatedFactoryList(
@@ -325,12 +320,14 @@ class EdxAuthUserFactory(factory.alchemy.SQLAlchemyModelFactory):
         "history_user",
         size=3,
         history_user_id=factory.SelfAttribute("..id"),
+        user_id=factory.SelfAttribute("..id"),
     )
     student_historicalcourseenrollment_user = factory.RelatedFactoryList(
         EdxStudentHistoricalcourseenrollmentFactory,
         "user",
         size=3,
         user_id=factory.SelfAttribute("..id"),
+        history_user_id=factory.SelfAttribute("..id"),
     )
     student_loginfailure = factory.RelatedFactoryList(
         EdxStudentLoginfailureFactory,
@@ -338,10 +335,10 @@ class EdxAuthUserFactory(factory.alchemy.SQLAlchemyModelFactory):
         size=3,
         user_id=factory.SelfAttribute("..id"),
     )
-    student_pendingemailchange = factory.SubFactory(
+    student_pendingemailchange = factory.RelatedFactory(
         EdxStudentPendingemailchangeFactory, user_id=factory.SelfAttribute("..id")
     )
-    student_userstanding_user = factory.SubFactory(
+    student_userstanding_user = factory.RelatedFactory(
         EdxStudentUserstandingFactory,
         changed_by_id=factory.SelfAttribute("..id"),
         user_id=factory.SelfAttribute("..id"),
@@ -358,6 +355,7 @@ class EdxAuthUserFactory(factory.alchemy.SQLAlchemyModelFactory):
             "reviewing_user",
             size=3,
             reviewing_user_id=factory.SelfAttribute("..id"),
+            user_id=factory.SelfAttribute("..id"),
         )
     )
     verify_student_softwaresecurephotoverification_user = factory.RelatedFactoryList(
@@ -365,4 +363,5 @@ class EdxAuthUserFactory(factory.alchemy.SQLAlchemyModelFactory):
         "user",
         size=3,
         user_id=factory.SelfAttribute("..id"),
+        reviewing_user_id=factory.SelfAttribute("..id"),
     )

--- a/src/app/mork/edx/factories/auth.py
+++ b/src/app/mork/edx/factories/auth.py
@@ -42,7 +42,6 @@ from .student import (
     EdxStudentHistoricalcourseenrollmentFactory,
     EdxStudentLanguageproficiencyFactory,
     EdxStudentLoginfailureFactory,
-    EdxStudentManualenrollmentauditFactory,
     EdxStudentPendingemailchangeFactory,
     EdxStudentUserstandingFactory,
 )
@@ -338,12 +337,6 @@ class EdxAuthUserFactory(factory.alchemy.SQLAlchemyModelFactory):
         "user",
         size=3,
         user_id=factory.SelfAttribute("..id"),
-    )
-    student_manualenrollmentaudit = factory.RelatedFactoryList(
-        EdxStudentManualenrollmentauditFactory,
-        "enrolled_by",
-        size=3,
-        enrolled_by_id=factory.SelfAttribute("..id"),
     )
     student_pendingemailchange = factory.SubFactory(
         EdxStudentPendingemailchangeFactory, user_id=factory.SelfAttribute("..id")

--- a/src/app/mork/edx/factories/base.py
+++ b/src/app/mork/edx/factories/base.py
@@ -1,12 +1,25 @@
 """Factory base configuration."""
 
+import factory
 from faker import Faker
 from sqlalchemy import create_engine
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import scoped_session, sessionmaker
 
 from mork.edx.models.base import Base
 
 faker = Faker()
 engine = create_engine("sqlite+pysqlite:///:memory:", echo=False, pool_pre_ping=True)
-session = Session(engine)
 Base.metadata.create_all(engine)
+
+Session = scoped_session(sessionmaker())
+
+
+class BaseSQLAlchemyModelFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Base factory class for SQLAlchemy models."""
+
+    class Meta:
+        """Factory configuration."""
+
+        abstract = True
+        sqlalchemy_session = Session
+        sqlalchemy_session_persistence = None

--- a/src/app/mork/edx/factories/bulk.py
+++ b/src/app/mork/edx/factories/bulk.py
@@ -4,17 +4,16 @@ import factory
 
 from mork.edx.models.bulk import BulkEmailCourseemail, BulkEmailOptout
 
-from .base import faker, session
+from .base import BaseSQLAlchemyModelFactory, faker
 
 
-class EdxBulkEmailCourseemailFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxBulkEmailCourseemailFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `bulk_email_courseemail` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = BulkEmailCourseemail
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     sender_id = factory.Sequence(lambda n: n + 1)
@@ -30,14 +29,13 @@ class EdxBulkEmailCourseemailFactory(factory.alchemy.SQLAlchemyModelFactory):
     from_addr = factory.Faker("text")
 
 
-class EdxBulkEmailOptoutFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxBulkEmailOptoutFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `bulk_email_optout` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = BulkEmailOptout
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     course_id = factory.Sequence(lambda n: f"course-v1:edX+{faker.pystr()}+{n}")

--- a/src/app/mork/edx/factories/certificates.py
+++ b/src/app/mork/edx/factories/certificates.py
@@ -7,11 +7,11 @@ from mork.edx.models.certificates import (
     CertificatesGeneratedcertificate,
 )
 
-from .base import faker, session
+from .base import BaseSQLAlchemyModelFactory, faker
 
 
 class EdxCertificatesCertificatehtmlviewconfigurationFactory(
-    factory.alchemy.SQLAlchemyModelFactory
+    BaseSQLAlchemyModelFactory
 ):
     """Factory for the `certificates_certificatehtmlviewconfiguration` table."""
 
@@ -19,7 +19,6 @@ class EdxCertificatesCertificatehtmlviewconfigurationFactory(
         """Factory configuration."""
 
         model = CertificatesCertificatehtmlviewconfiguration
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     change_date = factory.Faker("date_time")
@@ -28,16 +27,13 @@ class EdxCertificatesCertificatehtmlviewconfigurationFactory(
     configuration = factory.Faker("pystr")
 
 
-class EdxCertificatesGeneratedCertificateFactory(
-    factory.alchemy.SQLAlchemyModelFactory
-):
+class EdxCertificatesGeneratedCertificateFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `certificates_generatedcertificate` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = CertificatesGeneratedcertificate
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)

--- a/src/app/mork/edx/factories/contentstore.py
+++ b/src/app/mork/edx/factories/contentstore.py
@@ -4,17 +4,16 @@ import factory
 
 from mork.edx.models.contentstore import ContentstoreVideouploadconfig
 
-from .base import session
+from .base import BaseSQLAlchemyModelFactory
 
 
-class EdxContentstoreVideouploadconfigFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxContentstoreVideouploadconfigFactory(BaseSQLAlchemyModelFactory):
     """Model for the `contentstore_videouploadconfig` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = ContentstoreVideouploadconfig
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     change_date = factory.Faker("date_time")

--- a/src/app/mork/edx/factories/course.py
+++ b/src/app/mork/edx/factories/course.py
@@ -9,19 +9,16 @@ from mork.edx.models.course import (
     CourseGroupsCourseusergroupUsers,
 )
 
-from .base import faker, session
+from .base import BaseSQLAlchemyModelFactory, faker
 
 
-class EdxCourseActionStateCoursererunstateFactory(
-    factory.alchemy.SQLAlchemyModelFactory
-):
+class EdxCourseActionStateCoursererunstateFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `course_action_state_coursererunstate` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = CourseActionStateCoursererunstate
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     created_time = factory.Faker("date_time")
@@ -35,14 +32,13 @@ class EdxCourseActionStateCoursererunstateFactory(
     display_name = factory.Faker("text")
 
 
-class EdxCourseCreatorsCoursecreatorFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxCourseCreatorsCoursecreatorFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `course_creators_coursecreator` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = CourseCreatorsCoursecreator
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)
@@ -51,30 +47,26 @@ class EdxCourseCreatorsCoursecreatorFactory(factory.alchemy.SQLAlchemyModelFacto
     note = factory.Faker("text")
 
 
-class EdxCourseGroupsCourseusergroupUsersFactory(
-    factory.alchemy.SQLAlchemyModelFactory
-):
+class EdxCourseGroupsCourseusergroupUsersFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `course_groups_courseusergroup_users` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = CourseGroupsCourseusergroupUsers
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     courseusergroup_id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)
 
 
-class EdxCourseGroupsCohortmembershipFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxCourseGroupsCohortmembershipFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `course_groups_cohortmembership` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = CourseGroupsCohortmembership
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     course_user_group_id = factory.Sequence(lambda n: n + 1)

--- a/src/app/mork/edx/factories/courseware.py
+++ b/src/app/mork/edx/factories/courseware.py
@@ -10,17 +10,16 @@ from mork.edx.models.courseware import (
     CoursewareXmodulestudentprefsfield,
 )
 
-from .base import faker, session
+from .base import BaseSQLAlchemyModelFactory, faker
 
 
-class EdxCoursewareOfflinecomputedgradeFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxCoursewareOfflinecomputedgradeFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `courseware_offlinecomputedgrade` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = CoursewareOfflinecomputedgrade
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)
@@ -30,14 +29,13 @@ class EdxCoursewareOfflinecomputedgradeFactory(factory.alchemy.SQLAlchemyModelFa
     gradeset = factory.Faker("json")
 
 
-class EdxCoursewareStudentmodulehistoryFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxCoursewareStudentmodulehistoryFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `courseware_studentmodulehistory` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = CoursewareStudentmodulehistory
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     version = factory.Faker("pystr")
@@ -47,14 +45,13 @@ class EdxCoursewareStudentmodulehistoryFactory(factory.alchemy.SQLAlchemyModelFa
     max_grade = factory.Faker("pyfloat")
 
 
-class EdxCoursewareStudentmoduleFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxCoursewareStudentmoduleFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `courseware_studentmodule` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = CoursewareStudentmodule
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     module_type = factory.Faker(
@@ -78,16 +75,13 @@ class EdxCoursewareStudentmoduleFactory(factory.alchemy.SQLAlchemyModelFactory):
     )
 
 
-class EdxCoursewareXmodulestudentinfofieldFactory(
-    factory.alchemy.SQLAlchemyModelFactory
-):
+class EdxCoursewareXmodulestudentinfofieldFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `courseware_xmodulestudentinfofield` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = CoursewareXmodulestudentinfofield
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     field_name = factory.Faker("word")
@@ -97,16 +91,13 @@ class EdxCoursewareXmodulestudentinfofieldFactory(
     modified = factory.Faker("date_time")
 
 
-class EdxCoursewareXmodulestudentprefsfieldFactory(
-    factory.alchemy.SQLAlchemyModelFactory
-):
+class EdxCoursewareXmodulestudentprefsfieldFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `courseware_xmodulestudentprefsfield` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = CoursewareXmodulestudentprefsfield
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     field_name = factory.Faker("word")

--- a/src/app/mork/edx/factories/dark.py
+++ b/src/app/mork/edx/factories/dark.py
@@ -4,17 +4,16 @@ import factory
 
 from mork.edx.models.dark import DarkLangDarklangconfig
 
-from .base import session
+from .base import BaseSQLAlchemyModelFactory
 
 
-class EdxDarkLangDarklangconfigFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxDarkLangDarklangconfigFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `dark_lang_darklangconfig` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = DarkLangDarklangconfig
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     change_date = factory.Faker("date_time")

--- a/src/app/mork/edx/factories/django.py
+++ b/src/app/mork/edx/factories/django.py
@@ -4,17 +4,16 @@ import factory
 
 from mork.edx.models.django import DjangoCommentClientRoleUsers
 
-from .base import session
+from .base import BaseSQLAlchemyModelFactory
 
 
-class EdxDjangoCommentClientRoleUsersFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxDjangoCommentClientRoleUsersFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `django_comment_client_role_users` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = DjangoCommentClientRoleUsers
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     role_id = factory.Sequence(lambda n: n + 1)

--- a/src/app/mork/edx/factories/instructor.py
+++ b/src/app/mork/edx/factories/instructor.py
@@ -4,17 +4,16 @@ import factory
 
 from mork.edx.models.instructor import InstructorTaskInstructortask
 
-from .base import faker, session
+from .base import BaseSQLAlchemyModelFactory, faker
 
 
-class EdxInstructorTaskInstructortaskFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxInstructorTaskInstructortaskFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `instructor_task_instructortask` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = InstructorTaskInstructortask
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     task_type = factory.Faker("word")

--- a/src/app/mork/edx/factories/notify.py
+++ b/src/app/mork/edx/factories/notify.py
@@ -4,17 +4,16 @@ import factory
 
 from mork.edx.models.notify import NotifySetting
 
-from .base import session
+from .base import BaseSQLAlchemyModelFactory
 
 
-class EdxNotifySettingFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxNotifySettingFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `notify_settings` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = NotifySetting
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)

--- a/src/app/mork/edx/factories/payment.py
+++ b/src/app/mork/edx/factories/payment.py
@@ -4,17 +4,16 @@ import factory
 
 from mork.edx.models.payment import PaymentUseracceptance
 
-from .base import session
+from .base import BaseSQLAlchemyModelFactory
 
 
-class EdxPaymentUseracceptanceFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxPaymentUseracceptanceFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `payment_useracceptance` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = PaymentUseracceptance
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)

--- a/src/app/mork/edx/factories/proctoru.py
+++ b/src/app/mork/edx/factories/proctoru.py
@@ -4,17 +4,16 @@ import factory
 
 from mork.edx.models.proctoru import ProctoruProctoruexam, ProctoruProctoruuser
 
-from .base import session
+from .base import BaseSQLAlchemyModelFactory
 
 
-class EdxProctoruProctoruexamFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxProctoruProctoruexamFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `proctoru_proctoruexam` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = ProctoruProctoruexam
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)
@@ -30,14 +29,13 @@ class EdxProctoruProctoruexamFactory(factory.alchemy.SQLAlchemyModelFactory):
     url = factory.Faker("url")
 
 
-class EdxProctoruProctoruuserFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxProctoruProctoruuserFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `proctoru_proctoruuser` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = ProctoruProctoruuser
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     student_id = factory.Sequence(lambda n: n + 1)

--- a/src/app/mork/edx/factories/student.py
+++ b/src/app/mork/edx/factories/student.py
@@ -16,17 +16,16 @@ from mork.edx.models.student import (
     StudentUserstanding,
 )
 
-from .base import faker, session
+from .base import BaseSQLAlchemyModelFactory, faker
 
 
-class EdxStudentAnonymoususeridFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxStudentAnonymoususeridFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `student_anonymoususerid` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = StudentAnonymoususerid
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)
@@ -34,14 +33,13 @@ class EdxStudentAnonymoususeridFactory(factory.alchemy.SQLAlchemyModelFactory):
     course_id = factory.Sequence(lambda n: f"course-v1:edX+{faker.pystr()}+{n}")
 
 
-class EdxStudentCourseaccessroleFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxStudentCourseaccessroleFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `student_courseaccessrole` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = StudentCourseaccessrole
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)
@@ -50,14 +48,13 @@ class EdxStudentCourseaccessroleFactory(factory.alchemy.SQLAlchemyModelFactory):
     role = factory.Faker("word")
 
 
-class EdxStudentCourseenrollmentallowedFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxStudentCourseenrollmentallowedFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `student_courseenrollmentallowed` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = StudentCourseenrollmentallowed
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     email = factory.Faker("email")
@@ -66,16 +63,13 @@ class EdxStudentCourseenrollmentallowedFactory(factory.alchemy.SQLAlchemyModelFa
     auto_enroll = factory.Faker("random_int", min=0, max=1)
 
 
-class EdxStudentCourseenrollmentattributeFactory(
-    factory.alchemy.SQLAlchemyModelFactory
-):
+class EdxStudentCourseenrollmentattributeFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `student_courseenrollmentattribute` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = StudentCourseenrollmentattribute
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     enrollment_id = factory.Sequence(lambda n: n + 1)
@@ -84,16 +78,13 @@ class EdxStudentCourseenrollmentattributeFactory(
     value = factory.Faker("pystr")
 
 
-class EdxStudentHistoricalcourseenrollmentFactory(
-    factory.alchemy.SQLAlchemyModelFactory
-):
+class EdxStudentHistoricalcourseenrollmentFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `student_historicalcourseenrollment` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = StudentHistoricalcourseenrollment
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     course_id = factory.Sequence(lambda n: f"course-v1:edX+{faker.pystr()}+{n}")
@@ -107,28 +98,26 @@ class EdxStudentHistoricalcourseenrollmentFactory(
     history_type = factory.Faker("random_letter")
 
 
-class EdxStudentLanguageproficiencyFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxStudentLanguageproficiencyFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `student_languageproficiency` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = StudentLanguageproficiency
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_profile_id = factory.Sequence(lambda n: n + 1)
-    code = factory.Faker("pystr")
+    code = factory.Faker("pystr", max_chars=16)
 
 
-class EdxStudentLoginfailureFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxStudentLoginfailureFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `student_loginfailure` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = StudentLoginfailure
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)
@@ -136,14 +125,13 @@ class EdxStudentLoginfailureFactory(factory.alchemy.SQLAlchemyModelFactory):
     lockout_until = factory.Faker("date_time")
 
 
-class EdxStudentManualenrollmentauditFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxStudentManualenrollmentauditFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `student_manualenrollmentaudit` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = StudentManualenrollmentaudit
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     enrollment_id = factory.Sequence(lambda n: n + 1)
@@ -154,14 +142,13 @@ class EdxStudentManualenrollmentauditFactory(factory.alchemy.SQLAlchemyModelFact
     reason = factory.Faker("text")
 
 
-class EdxStudentCourseenrollmentFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxStudentCourseenrollmentFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `student_courseenrollment` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = StudentCourseenrollment
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)
@@ -184,14 +171,13 @@ class EdxStudentCourseenrollmentFactory(factory.alchemy.SQLAlchemyModelFactory):
     )
 
 
-class EdxStudentPendingemailchangeFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxStudentPendingemailchangeFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `student_pendingemailchange` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = StudentPendingemailchange
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)
@@ -199,14 +185,13 @@ class EdxStudentPendingemailchangeFactory(factory.alchemy.SQLAlchemyModelFactory
     activation_key = factory.Faker("hexify", text="^" * 32)
 
 
-class EdxStudentUserstandingFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxStudentUserstandingFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `student_userstanding` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = StudentUserstanding
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)

--- a/src/app/mork/edx/factories/user.py
+++ b/src/app/mork/edx/factories/user.py
@@ -4,17 +4,16 @@ import factory
 
 from mork.edx.models.user import UserApiUserpreference
 
-from .base import session
+from .base import BaseSQLAlchemyModelFactory
 
 
-class EdxUserApiUserpreferenceFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxUserApiUserpreferenceFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `user_api_userpreference` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = UserApiUserpreference
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     user_id = factory.Sequence(lambda n: n + 1)

--- a/src/app/mork/edx/factories/util.py
+++ b/src/app/mork/edx/factories/util.py
@@ -4,17 +4,16 @@ import factory
 
 from mork.edx.models.util import UtilRatelimitconfiguration
 
-from .base import session
+from .base import BaseSQLAlchemyModelFactory
 
 
-class EdxUtilRatelimitconfigurationFactory(factory.alchemy.SQLAlchemyModelFactory):
+class EdxUtilRatelimitconfigurationFactory(BaseSQLAlchemyModelFactory):
     """Model for the `util_ratelimitconfiguration` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = UtilRatelimitconfiguration
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     change_date = factory.Faker("date_time")

--- a/src/app/mork/edx/factories/verify.py
+++ b/src/app/mork/edx/factories/verify.py
@@ -7,19 +7,16 @@ from mork.edx.models.verify import (
     VerifyStudentSoftwaresecurephotoverification,
 )
 
-from .base import faker, session
+from .base import BaseSQLAlchemyModelFactory, faker
 
 
-class EdxVerifyStudentHistoricalverificationdeadlineFactory(
-    factory.alchemy.SQLAlchemyModelFactory
-):
+class EdxVerifyStudentHistoricalverificationdeadlineFactory(BaseSQLAlchemyModelFactory):
     """Factory for the `verify_student_historicalverificationdeadline` table."""
 
     class Meta:
         """Factory configuration."""
 
         model = VerifyStudentHistoricalverificationdeadline
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     created = factory.Faker("date_time")
@@ -34,7 +31,7 @@ class EdxVerifyStudentHistoricalverificationdeadlineFactory(
 
 
 class EdxVerifyStudentSoftwaresecurephotoverificationFactory(
-    factory.alchemy.SQLAlchemyModelFactory
+    BaseSQLAlchemyModelFactory
 ):
     """Factory for the `verify_student_softwaresecurephotoverification` table."""
 
@@ -42,7 +39,6 @@ class EdxVerifyStudentSoftwaresecurephotoverificationFactory(
         """Factory configuration."""
 
         model = VerifyStudentSoftwaresecurephotoverification
-        sqlalchemy_session = session
 
     id = factory.Sequence(lambda n: n + 1)
     status = factory.Faker("pystr")

--- a/src/app/mork/edx/models/auth.py
+++ b/src/app/mork/edx/models/auth.py
@@ -338,7 +338,7 @@ class AuthUserGroups(Base):
 
 
 class AuthRegistration(Base):
-    """Model for the `auth_registration`table."""
+    """Model for the `auth_registration` table."""
 
     __tablename__ = "auth_registration"
     __table_args__ = (

--- a/src/app/mork/edx/models/auth.py
+++ b/src/app/mork/edx/models/auth.py
@@ -39,7 +39,6 @@ from .student import (
     StudentHistoricalcourseenrollment,
     StudentLanguageproficiency,
     StudentLoginfailure,
-    StudentManualenrollmentaudit,
     StudentPendingemailchange,
     StudentUserstanding,
 )
@@ -258,13 +257,6 @@ class AuthUser(Base):
         "StudentLoginfailure",
         back_populates="user",
         cascade="all, delete-orphan",
-    )
-    student_manualenrollmentaudit: Mapped[List["StudentManualenrollmentaudit"]] = (
-        relationship(
-            "StudentManualenrollmentaudit",
-            back_populates="enrolled_by",
-            cascade="all, delete-orphan",
-        )
     )
     student_pendingemailchange: Mapped["StudentPendingemailchange"] = relationship(
         "StudentPendingemailchange",

--- a/src/app/mork/edx/models/student.py
+++ b/src/app/mork/edx/models/student.py
@@ -267,9 +267,6 @@ class StudentManualenrollmentaudit(Base):
     state_transition: Mapped[str] = mapped_column(String(255), nullable=False)
     reason: Mapped[str] = mapped_column(TEXT)
 
-    enrolled_by: Mapped["AuthUser"] = relationship(  # noqa: F821
-        "AuthUser", back_populates="student_manualenrollmentaudit"
-    )
     enrollment: Mapped["StudentCourseenrollment"] = relationship(
         "StudentCourseenrollment", back_populates="student_manualenrollmentaudit"
     )

--- a/src/app/mork/tests/fixtures/db.py
+++ b/src/app/mork/tests/fixtures/db.py
@@ -2,19 +2,20 @@
 
 import pytest
 from sqlalchemy import create_engine
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session as SASession
 
 from mork.conf import settings
 from mork.edx.database import OpenEdxDB
-from mork.edx.factories.base import engine, session
+from mork.edx.factories.base import Session, engine
 from mork.edx.models.base import Base as EdxBase
 from mork.models import Base
 
 
 @pytest.fixture
 def edx_db():
-    """"""
-    db = OpenEdxDB(engine, session)
+    """Test edx MySQL database fixture."""
+    Session.configure(bind=engine)
+    db = OpenEdxDB(engine, Session)
     EdxBase.metadata.create_all(engine)
     yield db
     db.session.rollback()
@@ -43,7 +44,7 @@ def db_session(db_engine):
     # is bound to the test session.
     connection = db_engine.connect()
     transaction = connection.begin()
-    session = Session(bind=connection)
+    session = SASession(bind=connection)
 
     yield session
 


### PR DESCRIPTION
## Purpose

1. The relationships in the `student_manualenrollmentaudit` are incorrect.
2. Since the introduction of the edx MySQL models, the seeding script has stopped working.

## Proposal

1. [x] The `student_manualenrollmentaudit` table is a child of the `student_coursenrollment` table, which is a child of the `auth_user` table. When a user is deleted, Mork should delete the corresponding enrollments and the corresponding manual enrollment audits. We don't want to delete based on the `enrolled_by` field
2. [x] We rely on factories to generate fake data into the MySQL development database. To ensure compatibility with both testing and seeding use cases, the factories need some proper configuration, mainly on handling the session and the persistency.
Additionally, subfactories were used to cascade factory creation, which works in tests but fails when committing to a real development database. These subfactories have been replaced with factoryboy related factories to resolve the issue.

