### PR TITLE
✨(api) add dry-run mode to protect against unintended actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Changed
+
+- Add a dry-run parameter to the task creation API (defaults to True)
+
 ## [0.3.0] - 2024-11-04
 
 ## Added

--- a/src/app/mork/api/models.py
+++ b/src/app/mork/api/models.py
@@ -35,6 +35,7 @@ class TaskCreateBase(BaseModel):
     """Base model for creating a task."""
 
     model_config = ConfigDict(extra="ignore")
+    dry_run: bool = True
 
 
 class DeleteInactiveUsers(TaskCreateBase):

--- a/src/app/mork/edx/factories/student.py
+++ b/src/app/mork/edx/factories/student.py
@@ -168,6 +168,7 @@ class EdxStudentCourseenrollmentFactory(BaseSQLAlchemyModelFactory):
         "enrollment",
         size=3,
         enrollment_id=factory.SelfAttribute("..id"),
+        enrolled_by_id=factory.SelfAttribute("..user_id"),
     )
 
 


### PR DESCRIPTION
## Purpose

We need to avoid any unintended action through the API

## Proposal

Introduce safety measure for task execution:
- Add a dry\_run parameter to task creation API (defaults to True),
- Add a dry\_run parameter to tasks so they are still executed without
performing an action.

_Note:_ On a side note, fixing the MySQL dev seeding script that is still failing
