### PR TITLE
🐛(api) fix session lifecycle on heartbeat endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to
 
 - Add a dry-run parameter to the task creation API (defaults to True)
 
+## Fixed
+
+- Fix HTTP 500 errors on heartbeat endpoint when QueuePool limits are reached
+
 ## [0.3.0] - 2024-11-04
 
 ## Added

--- a/src/app/logging-config.dev.yaml
+++ b/src/app/logging-config.dev.yaml
@@ -32,7 +32,7 @@ loggers:
       - access
     level: INFO
     propagate: false
-  mork.api:
+  mork:
     handlers:
       - default
     level: DEBUG

--- a/src/app/mork/api/routes/health.py
+++ b/src/app/mork/api/routes/health.py
@@ -2,10 +2,13 @@
 
 import logging
 from enum import Enum
+from typing import Annotated
 
-from fastapi import APIRouter, Response, status
+from fastapi import APIRouter, Depends, Response, status
 from pydantic import BaseModel
+from sqlalchemy.orm import Session
 
+from mork.database import get_session
 from mork.database import is_alive as is_db_alive
 
 logger = logging.getLogger(__name__)
@@ -44,13 +47,15 @@ async def lbheartbeat() -> None:
 
 
 @router.get("/__heartbeat__", status_code=status.HTTP_200_OK)
-async def heartbeat(response: Response) -> Heartbeat:
+async def heartbeat(
+    session: Annotated[Session, Depends(get_session)], response: Response
+) -> Heartbeat:
     """Application heartbeat.
 
     Return a 200 if all checks are successful.
     """
     statuses = Heartbeat(
-        database=DatabaseStatus.OK if is_db_alive() else DatabaseStatus.ERROR,
+        database=DatabaseStatus.OK if is_db_alive(session) else DatabaseStatus.ERROR,
     )
     if not statuses.is_alive:
         response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/src/app/mork/database.py
+++ b/src/app/mork/database.py
@@ -70,11 +70,11 @@ def get_session() -> Generator[SASession, None, None]:
     with SASession(bind=get_engine()) as session:
         logger.debug("Getting session %s", session)
         yield session
+        logger.debug("Closing session %s", session)
 
 
-def is_alive() -> bool:
+def is_alive(session: SASession) -> bool:
     """Check if database connection is alive."""
-    session = next(get_session())
     try:
         session.execute(text("SELECT 1 as is_alive"))
         return True

--- a/src/app/mork/tests/api/test_health.py
+++ b/src/app/mork/tests/api/test_health.py
@@ -9,3 +9,19 @@ async def test_api_health_lbheartbeat(http_client):
     response = await http_client.get("/__lbheartbeat__")
     assert response.status_code == 200
     assert response.json() is None
+
+
+@pytest.mark.anyio
+async def test_api_health_heartbeat(db_session, http_client, monkeypatch):
+    """Test the heartbeat healthcheck."""
+    monkeypatch.setattr("mork.database.get_session", db_session)
+
+    response = await http_client.get("/__heartbeat__")
+    assert response.status_code == 200
+    assert response.json() == {"database": "ok"}
+
+    monkeypatch.setattr("mork.api.routes.health.is_db_alive", lambda x: False)
+
+    response = await http_client.get("/__heartbeat__")
+    assert response.status_code == 500
+    assert response.json() == {"database": "error"}


### PR DESCRIPTION
## Purpose

The `__heartbeat__` endpoint occasionally returned HTTP 500 errors.

## Proposal

Session were not closed after requests, leading to the connection pool exhaustion.
Fixing it by making sure the session are properly managed.

