### PR TITLE
✨(celery) add marking of user before deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to
 ## Added
 
 - Add edx mongodb connection to anonymize personal data from edx forums
-- Add `users` endpoints for services to retrieve the list of users to delete  
+- Add `users` endpoints for services to retrieve the list of users to delete
+- Flag users for deletion in Mork database when deletion process begins
+- Add status verification checks before and after user deletion in edX
 
 ## Changed
 

--- a/src/app/mork/celery/tasks/deletion.py
+++ b/src/app/mork/celery/tasks/deletion.py
@@ -2,17 +2,27 @@
 
 from datetime import datetime
 from logging import getLogger
+from uuid import UUID
 
-from celery import group
+from celery import chain, group
+from sqlalchemy import insert, select
 from sqlalchemy.exc import SQLAlchemyError
 
 from mork.celery.celery_app import app
+from mork.celery.tasks.edx import delete_edx_platform_user
 from mork.conf import settings
 from mork.db import MorkDB
 from mork.edx.mysql import crud
 from mork.edx.mysql.database import OpenEdxMySQLDB
 from mork.exceptions import UserDeleteError
 from mork.models.tasks import EmailStatus
+from mork.models.users import (
+    DeletionReason,
+    DeletionStatus,
+    ServiceName,
+    User,
+    UserServiceStatus,
+)
 
 logger = getLogger(__name__)
 
@@ -20,80 +30,134 @@ logger = getLogger(__name__)
 @app.task
 def delete_inactive_users(dry_run: bool = True):
     """Celery task to delete inactive users accounts."""
-    db = OpenEdxMySQLDB()
+    edx_db = OpenEdxMySQLDB()
+
     threshold_date = datetime.now() - settings.DELETION_PERIOD
 
-    total = crud.get_inactive_users_count(db.session, threshold_date)
+    total = crud.get_inactive_users_count(edx_db.session, threshold_date)
     for batch_offset in range(0, total, settings.EDX_MYSQL_QUERY_BATCH_SIZE):
         inactive_users = crud.get_inactive_users(
-            db.session,
+            edx_db.session,
             threshold_date,
             offset=batch_offset,
             limit=settings.EDX_MYSQL_QUERY_BATCH_SIZE,
         )
+
         delete_group = group(
             [
-                delete_user.s(email=user.email, dry_run=dry_run)
+                delete_user.s(
+                    email=user.email, reason=DeletionReason.GDPR, dry_run=dry_run
+                )
                 for user in inactive_users
             ]
         )
         delete_group.delay()
 
+    edx_db.session.close()
 
-@app.task(
-    bind=True,
-    retry_kwargs={"max_retries": settings.DELETE_MAX_RETRIES},
-)
-def delete_user(self, email: str, dry_run: bool = True):
-    """Celery task that delete a specified user."""
+
+@app.task
+def delete_user(
+    email: str,
+    reason: DeletionReason = DeletionReason.USER_REQUESTED,
+    dry_run: bool = True,
+):
+    """Celery task that deletes a specific user."""
     if dry_run:
         logger.info(f"Dry run: User with {email=} would have been deleted")
         return
 
-    logger.info(f"Deleting user with {email=}")
+    logger.info(f"Starting deletion of user with {email=}")
+
+    delete_chain = chain(
+        remove_email_status.si(email),
+        mark_user_for_deletion.si(email=email, reason=reason),
+        delete_edx_platform_user.s(),
+    )
+
+    delete_chain.delay()
+
+
+@app.task
+def mark_user_for_deletion(email: str, reason: DeletionReason) -> UUID:
+    """Mark user for deletion across all services in Mork database."""
+    logger.debug("Marking user for deletion")
+
+    edx_mysql_db = OpenEdxMySQLDB()
+    edx_mysql_db.session.expire_on_commit = False
+
+    auth_user = crud.get_user(edx_mysql_db.session, email)
+
+    edx_mysql_db.session.close()
+
+    if not auth_user:
+        msg = f"User with {email=} not found in edx database"
+        logger.error(msg)
+        raise UserDeleteError(msg)
+
+    mork_db = MorkDB()
+
+    # Check if user already exist in Mork database
+    user_exist = mork_db.session.scalar(select(User).where(User.email == email))
+    if user_exist:
+        logger.info(f"User with {email=} is already marked for deletion")
+        return user_exist.id
+
+    # Add user to Mork database
+    user_id = mork_db.session.scalar(
+        insert(User)
+        .returning(User.id)
+        .values(
+            username=auth_user.username,
+            edx_user_id=auth_user.id,
+            email=auth_user.email,
+            reason=reason,
+        )
+    )
+
+    # Mark for deletion across all services
+    mork_db.session.execute(
+        insert(UserServiceStatus),
+        [
+            {
+                "user_id": user_id,
+                "service_name": service,
+                "status": DeletionStatus.TO_DELETE,
+            }
+            for service in ServiceName
+        ],
+    )
+
     try:
-        delete_user_from_db(email)
-    except UserDeleteError as exc:
-        logger.exception(exc)
-        raise self.retry(exc=exc) from exc
-
-    # Delete email status flag in mork database
-    delete_email_status(email)
-
-
-def delete_user_from_db(email):
-    """Delete user from edX database."""
-    db = OpenEdxMySQLDB()
-
-    # Delete user from edX database
-    crud.delete_user(db.session, email=email)
-    try:
-        db.session.commit()
+        mork_db.session.commit()
     except SQLAlchemyError as exc:
-        db.session.rollback()
-        logger.error(f"Failed to delete user with {email=}: {exc}")
-        raise UserDeleteError("Failed to delete user.") from exc
+        mork_db.session.rollback()
+        logger.error(f"Failed to mark user to be deleted - {exc}")
+        raise UserDeleteError("Failed to mark user to be deleted") from exc
     finally:
-        db.session.close()
+        mork_db.session.close()
+
+    return user_id
 
 
-def delete_email_status(email: str):
+@app.task
+def remove_email_status(email: str):
     """Delete the email status in the Mork database."""
-    # Delete user from Mork email status database
+    logger.debug("Removing user email status")
     mork_db = MorkDB()
     user_to_delete = (
         mork_db.session.query(EmailStatus).filter(EmailStatus.email == email).first()
     )
     if not user_to_delete:
-        logger.warning(f"Email status - No user found with {email=} for deletion")
+        logger.warning("Email status - No user found with email %s for deletion", email)
         return
 
     mork_db.session.delete(user_to_delete)
     try:
         mork_db.session.commit()
-    except SQLAlchemyError as exc:
+    except SQLAlchemyError:
         mork_db.session.rollback()
-        logger.error(f"Email status - Failed to delete user with {email=}: {exc}")
+        logger.error("Email status - Failed to delete user with email %s", email)
         return
     finally:
         mork_db.session.close()

--- a/src/app/mork/celery/tasks/edx.py
+++ b/src/app/mork/celery/tasks/edx.py
@@ -1,0 +1,85 @@
+"""Mork Celery edx tasks."""
+
+from logging import getLogger
+from uuid import UUID
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from mork.celery.celery_app import app
+from mork.celery.utils import (
+    get_service_status,
+    get_user_from_mork,
+    update_status_in_mork,
+)
+from mork.conf import settings
+from mork.edx.mysql import crud as mysql
+from mork.edx.mysql.database import OpenEdxMySQLDB
+from mork.exceptions import (
+    UserDeleteError,
+    UserNotFound,
+    UserProtected,
+    UserStatusError,
+)
+from mork.models.users import DeletionStatus, ServiceName
+
+logger = getLogger(__name__)
+
+
+@app.task(
+    bind=True,
+    retry_kwargs={"max_retries": settings.DELETE_MAX_RETRIES},
+)
+def delete_edx_platform_user(self, user_id: UUID):
+    """Task to delete user from the edX platform."""
+    user = get_user_from_mork(user_id)
+    if not user:
+        msg = f"User {user_id} could not be retrieved from Mork"
+        logger.error(msg)
+        raise UserNotFound(msg)
+
+    status = get_service_status(user, ServiceName.EDX)
+    if status != DeletionStatus.TO_DELETE:
+        msg = f"User {user_id} is not to be deleted. Status: {status}"
+        logger.error(msg)
+        raise UserStatusError(msg)
+
+    try:
+        delete_edx_mysql_user(email=user.email)
+        delete_edx_mongo_user(username=user.username)
+    except UserDeleteError as exc:
+        raise self.retry(exc=exc) from exc
+
+    if not update_status_in_mork(
+        user_id=user_id, service=ServiceName.EDX, status=DeletionStatus.DELETED
+    ):
+        msg = f"Failed to update deletion status to deleted for user {user_id}"
+        logger.error(msg)
+        raise UserStatusError(msg)
+
+    logger.info(f"Completed deletion process for user {user_id}")
+
+
+def delete_edx_mysql_user(email: str):
+    """Delete user's data from edX MySQL database."""
+    logger.debug("Deleting user's data from edX MySQL")
+
+    db = OpenEdxMySQLDB()
+    try:
+        mysql.delete_user(db.session, email=email)
+        db.session.commit()
+    except (UserProtected, UserNotFound) as exc:
+        db.session.rollback()
+        logger.info(f"Skipping MySQL deletion for user with {email=} : {exc}")
+    except SQLAlchemyError as exc:
+        db.session.rollback()
+        msg = f"Failed to delete user with {email=} from edX MySQL"
+        logger.error(msg)
+        raise UserDeleteError(msg) from exc
+    finally:
+        db.session.close()
+
+
+def delete_edx_mongo_user(username: str):  # noqa: ARG001
+    """Delete user's data from edX MongoDB database."""
+    logger.debug("Deleting user's data from edX MongoDB")
+    pass

--- a/src/app/mork/celery/utils.py
+++ b/src/app/mork/celery/utils.py
@@ -1,0 +1,60 @@
+"""Celery utils functions."""
+
+from logging import getLogger
+from uuid import UUID
+
+import httpx
+
+from mork.conf import settings
+from mork.models.users import DeletionStatus, ServiceName
+from mork.schemas.users import UserRead
+
+logger = getLogger(__name__)
+
+
+def get_user_from_mork(user_id: UUID) -> UserRead | None:
+    """Retrieve user from Mork by ID."""
+    logger.debug("Get user from Mork")
+    logger.debug(f"API URL: {settings.SERVER_URL}")
+
+    try:
+        response = httpx.get(
+            f"{settings.SERVER_URL}/v1/users/{user_id}",
+            headers={"X-API-Key": f"{settings.API_KEYS[0]}"},
+        )
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.error(f"Failed to retrieve user from Mork API: {exc}")
+        return None
+
+    return UserRead.model_validate(response.json())
+
+
+def get_service_status(user: UserRead, service: ServiceName) -> DeletionStatus | None:
+    """Find the service status entry for a user."""
+    service_status = next(
+        (status for status in user.service_statuses if status.service_name == service),
+        None,
+    )
+    return service_status.status if service_status else None
+
+
+def update_status_in_mork(
+    user_id: UUID, service: ServiceName, status: DeletionStatus
+) -> bool:
+    """Update the user deletion status in Mork."""
+    logger.debug(f"Updating deletion status for user {user_id} in Mork to {status}")
+    logger.debug(f"API URL: {settings.SERVER_URL}")
+
+    try:
+        response = httpx.patch(
+            f"{settings.SERVER_URL}/v1/users/{user_id}/status/{service.value}",
+            headers={"X-API-Key": f"{settings.API_KEYS[0]}"},
+            json={"deletion_status": status.value},
+        )
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.error(f"Failed to update user status with Mork API: {exc}")
+        return False
+
+    return True

--- a/src/app/mork/edx/mysql/factories/courseware.py
+++ b/src/app/mork/edx/mysql/factories/courseware.py
@@ -84,7 +84,7 @@ class EdxCoursewareXmodulestudentinfofieldFactory(BaseSQLAlchemyModelFactory):
         model = CoursewareXmodulestudentinfofield
 
     id = factory.Sequence(lambda n: n + 1)
-    field_name = factory.Faker("word")
+    field_name = factory.Faker("pystr", max_chars=64)
     value = factory.Faker("random_element", elements=["true", "false"])
     student_id = factory.Sequence(lambda n: n + 1)
     created = factory.Faker("date_time")

--- a/src/app/mork/exceptions.py
+++ b/src/app/mork/exceptions.py
@@ -13,5 +13,13 @@ class UserDeleteError(Exception):
     """Raised when an error occurs when deleting a user."""
 
 
-class UserProtectedDeleteError(Exception):
+class UserNotFound(Exception):
+    """Raised when a user has not been found."""
+
+
+class UserStatusError(Exception):
+    """Raised when an error occurs when checking a user status."""
+
+
+class UserProtected(Exception):
     """Raised when a user is associated with an entry in a protected table."""

--- a/src/app/mork/tests/celery/tasks/test_edx.py
+++ b/src/app/mork/tests/celery/tasks/test_edx.py
@@ -1,0 +1,259 @@
+"""Tests for Mork Celery edx tasks."""
+
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+
+from mork.celery.tasks.edx import delete_edx_mysql_user, delete_edx_platform_user
+from mork.edx.mysql import crud
+from mork.edx.mysql.factories.auth import EdxAuthUserFactory
+from mork.exceptions import (
+    UserDeleteError,
+    UserNotFound,
+    UserProtected,
+    UserStatusError,
+)
+from mork.factories.users import UserFactory, UserServiceStatusFactory
+from mork.models.users import DeletionStatus, ServiceName, User
+from mork.schemas.users import UserRead
+
+
+def test_delete_edx_platform_user(db_session, monkeypatch):
+    """Test to delete user from edX platform."""
+    UserServiceStatusFactory._meta.sqlalchemy_session = db_session
+    UserFactory._meta.sqlalchemy_session = db_session
+
+    # Create one user in the database
+    UserFactory.create()
+
+    # Get user from db
+    user = UserRead.model_validate(db_session.scalar(select(User)))
+
+    monkeypatch.setattr("mork.celery.tasks.edx.get_user_from_mork", lambda x: user)
+
+    mock_delete_edx_mysql_user = Mock()
+    monkeypatch.setattr(
+        "mork.celery.tasks.edx.delete_edx_mysql_user", mock_delete_edx_mysql_user
+    )
+    mock_delete_edx_mongo_user = Mock()
+    monkeypatch.setattr(
+        "mork.celery.tasks.edx.delete_edx_mongo_user", mock_delete_edx_mongo_user
+    )
+    mock_update_status_in_mork = Mock(return_value=True)
+    monkeypatch.setattr(
+        "mork.celery.tasks.edx.update_status_in_mork", mock_update_status_in_mork
+    )
+
+    delete_edx_platform_user(user.id)
+
+    mock_delete_edx_mysql_user.assert_called_once_with(email=user.email)
+    mock_delete_edx_mongo_user.assert_called_once_with(username=user.username)
+    mock_update_status_in_mork.assert_called_once_with(
+        user_id=user.id, service=ServiceName.EDX, status=DeletionStatus.DELETED
+    )
+
+
+def test_delete_edx_platform_user_invalid_user(monkeypatch):
+    """Test to delete user from edX platform with an invalid user."""
+
+    monkeypatch.setattr("mork.celery.tasks.edx.get_user_from_mork", lambda x: None)
+
+    mock_delete_edx_mysql_user = Mock()
+    monkeypatch.setattr(
+        "mork.celery.tasks.edx.delete_edx_mysql_user", mock_delete_edx_mysql_user
+    )
+    mock_delete_edx_mongo_user = Mock()
+    monkeypatch.setattr(
+        "mork.celery.tasks.edx.delete_edx_mongo_user", mock_delete_edx_mongo_user
+    )
+    mock_update_status_in_mork = Mock(return_value=True)
+    monkeypatch.setattr(
+        "mork.celery.tasks.edx.update_status_in_mork", mock_update_status_in_mork
+    )
+
+    nonexistent_id = uuid4().hex
+    with pytest.raises(
+        UserNotFound, match=f"User {nonexistent_id} could not be retrieved from Mork"
+    ):
+        delete_edx_platform_user(nonexistent_id)
+
+    mock_delete_edx_mysql_user.assert_not_called()
+    mock_delete_edx_mongo_user.assert_not_called()
+    mock_update_status_in_mork.assert_not_called()
+
+
+def test_delete_edx_platform_user_invalid_status(db_session, monkeypatch):
+    """Test to delete user from edX platform with an invalid status."""
+    UserServiceStatusFactory._meta.sqlalchemy_session = db_session
+    UserFactory._meta.sqlalchemy_session = db_session
+
+    # Create one user in the database that is already deleted on edx
+    UserFactory.create(
+        service_statuses={ServiceName.EDX: DeletionStatus.DELETED},
+    )
+
+    # Get user from db
+    user = UserRead.model_validate(db_session.scalar(select(User)))
+
+    monkeypatch.setattr("mork.celery.tasks.edx.get_user_from_mork", lambda x: user)
+
+    mock_delete_edx_mysql_user = Mock()
+    monkeypatch.setattr(
+        "mork.celery.tasks.edx.delete_edx_mysql_user", mock_delete_edx_mysql_user
+    )
+    mock_delete_edx_mongo_user = Mock()
+    monkeypatch.setattr(
+        "mork.celery.tasks.edx.delete_edx_mongo_user", mock_delete_edx_mongo_user
+    )
+    mock_update_status_in_mork = Mock(return_value=True)
+    monkeypatch.setattr(
+        "mork.celery.tasks.edx.update_status_in_mork", mock_update_status_in_mork
+    )
+
+    with pytest.raises(
+        UserStatusError,
+        match=f"User {str(user.id)} is not to be deleted. Status: DeletionStatus.DELETED",  # noqa: E501
+    ):
+        delete_edx_platform_user(user.id)
+
+    mock_delete_edx_mysql_user.assert_not_called()
+    mock_delete_edx_mongo_user.assert_not_called()
+    mock_update_status_in_mork.assert_not_called()
+
+
+def test_delete_edx_platform_user_failed_delete(db_session, monkeypatch):
+    """Test to delete user from edX platform with a failed delete."""
+    UserServiceStatusFactory._meta.sqlalchemy_session = db_session
+    UserFactory._meta.sqlalchemy_session = db_session
+
+    # Create one user in the database that is already deleted on edx
+    UserFactory.create()
+
+    # Get user from db
+    user = UserRead.model_validate(db_session.scalar(select(User)))
+
+    monkeypatch.setattr("mork.celery.tasks.edx.get_user_from_mork", lambda x: user)
+
+    def mock_delete_edx_mysql_user(*args, **kwars):
+        raise UserDeleteError("An error occurred")
+
+    monkeypatch.setattr(
+        "mork.celery.tasks.edx.delete_edx_mysql_user", mock_delete_edx_mysql_user
+    )
+    mock_delete_edx_mongo_user = Mock()
+    monkeypatch.setattr(
+        "mork.celery.tasks.edx.delete_edx_mongo_user", mock_delete_edx_mongo_user
+    )
+
+    with pytest.raises(UserDeleteError, match="An error occurred"):
+        delete_edx_platform_user(user.id)
+
+
+def test_delete_edx_platform_user_failed_status_update(db_session, monkeypatch):
+    """Test to delete user from edX platform with a failed status update."""
+    UserServiceStatusFactory._meta.sqlalchemy_session = db_session
+    UserFactory._meta.sqlalchemy_session = db_session
+
+    # Create one user in the database that is already deleted on edx
+    UserFactory.create()
+
+    # Get user from db
+    user = UserRead.model_validate(db_session.scalar(select(User)))
+
+    monkeypatch.setattr("mork.celery.tasks.edx.get_user_from_mork", lambda x: user)
+
+    mock_delete_edx_mysql_user = Mock()
+    monkeypatch.setattr(
+        "mork.celery.tasks.edx.delete_edx_mysql_user", mock_delete_edx_mysql_user
+    )
+    mock_delete_edx_mongo_user = Mock()
+    monkeypatch.setattr(
+        "mork.celery.tasks.edx.delete_edx_mongo_user", mock_delete_edx_mongo_user
+    )
+    mock_update_status_in_mork = Mock(return_value=False)
+    monkeypatch.setattr(
+        "mork.celery.tasks.edx.update_status_in_mork", mock_update_status_in_mork
+    )
+
+    with pytest.raises(
+        UserStatusError,
+        match=f"Failed to update deletion status to deleted for user {user.id}",
+    ):
+        delete_edx_platform_user(user.id)
+
+
+def test_delete_edx_mysql_user(edx_mysql_db, monkeypatch):
+    """Test to delete user's data from MySQL."""
+    EdxAuthUserFactory._meta.sqlalchemy_session = edx_mysql_db.session
+    EdxAuthUserFactory.create(email="johndoe1@example.com")
+    EdxAuthUserFactory.create(email="johndoe2@example.com")
+
+    monkeypatch.setattr(
+        "mork.celery.tasks.edx.OpenEdxMySQLDB", lambda *args: edx_mysql_db
+    )
+
+    # Check both users exist on the MySQL database
+    assert crud.get_user(
+        edx_mysql_db.session,
+        email="johndoe1@example.com",
+    )
+    assert crud.get_user(
+        edx_mysql_db.session,
+        email="johndoe2@example.com",
+    )
+
+    delete_edx_mysql_user(email="johndoe1@example.com")
+
+    # Check only one remains
+    assert not crud.get_user(
+        edx_mysql_db.session,
+        email="johndoe1@example.com",
+    )
+    assert crud.get_user(
+        edx_mysql_db.session,
+        email="johndoe2@example.com",
+    )
+
+
+def test_delete_edx_mysql_user_protected(edx_mysql_db, monkeypatch):
+    """Test to delete data from MySQL for a protected user."""
+    EdxAuthUserFactory._meta.sqlalchemy_session = edx_mysql_db.session
+    email = "johndoe1@example.com"
+    EdxAuthUserFactory.create(email=email)
+
+    def mock_delete_user(*args, **kwargs):
+        raise UserProtected("An error occurred")
+
+    monkeypatch.setattr("mork.celery.tasks.edx.mysql.delete_user", mock_delete_user)
+
+    delete_edx_mysql_user(email=email)
+
+    # Check the user still exists on the edX MySQL database
+    assert crud.get_user(
+        edx_mysql_db.session,
+        email="johndoe1@example.com",
+    )
+
+
+def test_delete_edx_mysql_user_with_failure(edx_mysql_db, monkeypatch):
+    """Test to delete user's data from MySQL with a commit failure."""
+    EdxAuthUserFactory._meta.sqlalchemy_session = edx_mysql_db.session
+    email = "johndoe1@example.com"
+    EdxAuthUserFactory.create(email=email)
+
+    def mock_session_commit():
+        raise SQLAlchemyError("An error occurred")
+
+    edx_mysql_db.session.commit = mock_session_commit
+    monkeypatch.setattr(
+        "mork.celery.tasks.edx.OpenEdxMySQLDB", lambda *args: edx_mysql_db
+    )
+
+    with pytest.raises(
+        UserDeleteError,
+        match=f"Failed to delete user with email='{email}' from edX MySQL",
+    ):
+        delete_edx_mysql_user(email=email)

--- a/src/app/mork/tests/celery/test_utils.py
+++ b/src/app/mork/tests/celery/test_utils.py
@@ -1,0 +1,148 @@
+"""Tests for Mork Celery utils."""
+
+import re
+
+from pytest_httpx import HTTPXMock
+from sqlalchemy import select
+
+from mork.celery.utils import (
+    get_service_status,
+    get_user_from_mork,
+    update_status_in_mork,
+)
+from mork.factories.users import UserFactory, UserServiceStatusFactory
+from mork.models.users import DeletionStatus, ServiceName, User
+from mork.schemas.users import UserRead
+
+
+def test_get_user_from_mork(db_session, httpx_mock: HTTPXMock):
+    """Test the behavior of getting a user from Mork API."""
+
+    UserServiceStatusFactory._meta.sqlalchemy_session = db_session
+    UserFactory._meta.sqlalchemy_session = db_session
+
+    # Create one user in the database
+    UserFactory.create()
+
+    # Get user from db
+    expected_user = UserRead.model_validate(db_session.scalar(select(User)))
+
+    httpx_mock.add_response(
+        url=re.compile(rf".*v1/users/{expected_user.id}"),
+        method="GET",
+        json=expected_user.model_dump(mode="json"),
+        status_code=200,
+    )
+
+    user = get_user_from_mork(expected_user.id)
+
+    assert user == expected_user
+
+
+def test_get_user_from_mork_invalid(db_session, httpx_mock: HTTPXMock):
+    """Test the behavior of getting a user from Mork with invalid user id or status."""
+
+    UserServiceStatusFactory._meta.sqlalchemy_session = db_session
+    UserFactory._meta.sqlalchemy_session = db_session
+
+    # Create one user in the database
+    UserFactory.create()
+
+    # Get user from db
+    expected_user = UserRead.model_validate(db_session.scalar(select(User)))
+
+    httpx_mock.add_response(
+        url=re.compile(rf".*v1/users/{expected_user.id}"),
+        method="GET",
+        status_code=404,
+    )
+
+    assert get_user_from_mork(expected_user.id) is None
+
+
+def test_get_service_status(db_session, httpx_mock: HTTPXMock):
+    """Test the behavior of getting the status from a user."""
+
+    UserServiceStatusFactory._meta.sqlalchemy_session = db_session
+    UserFactory._meta.sqlalchemy_session = db_session
+
+    # Create one user in the database
+    expected_status = DeletionStatus.DELETED
+    UserFactory.create(
+        service_statuses={ServiceName.EDX: expected_status},
+    )
+
+    # Get user from db
+    expected_user = UserRead.model_validate(db_session.scalar(select(User)))
+
+    status = get_service_status(expected_user, ServiceName.EDX)
+
+    assert status == expected_status
+
+
+def test_get_service_status_not_found(db_session, httpx_mock: HTTPXMock):
+    """Test the behavior of getting a inexistent status from a user."""
+
+    UserServiceStatusFactory._meta.sqlalchemy_session = db_session
+    UserFactory._meta.sqlalchemy_session = db_session
+
+    # Create one user in the database
+    UserFactory.create()
+
+    # Get user from db
+    expected_user = UserRead.model_validate(db_session.scalar(select(User)))
+
+    # Remove statuses of the user
+    expected_user.service_statuses = []
+
+    status = get_service_status(expected_user, ServiceName.EDX)
+
+    assert status is None
+
+
+def test_update_status_in_mork(db_session, httpx_mock: HTTPXMock):
+    """Test the behavior of updating the user status."""
+
+    UserServiceStatusFactory._meta.sqlalchemy_session = db_session
+    UserFactory._meta.sqlalchemy_session = db_session
+
+    # Create one user in the database
+    UserFactory.create()
+
+    # Get id of one of the newly created user
+    user_id = db_session.scalar(select(User.id))
+
+    service_name = "ashley"
+
+    httpx_mock.add_response(
+        url=re.compile(rf".*v1/users/{user_id}/status/{service_name}"),
+        method="PATCH",
+        status_code=200,
+    )
+
+    success = update_status_in_mork(user_id, ServiceName.ASHLEY, DeletionStatus.DELETED)
+    assert success
+
+
+def test_update_user_status_invalid(db_session, httpx_mock: HTTPXMock):
+    """Test the behavior of updating the user status with an invalid response."""
+
+    UserServiceStatusFactory._meta.sqlalchemy_session = db_session
+    UserFactory._meta.sqlalchemy_session = db_session
+
+    # Create one user in the database
+    UserFactory.create()
+
+    # Get id of one of the newly created user
+    user_id = db_session.scalar(select(User.id))
+
+    service_name = "ashley"
+
+    httpx_mock.add_response(
+        url=re.compile(rf".*v1/users/{user_id}/status/{service_name}"),
+        method="PATCH",
+        status_code=404,
+    )
+
+    success = update_status_in_mork(user_id, ServiceName.ASHLEY, DeletionStatus.DELETED)
+    assert not success


### PR DESCRIPTION
## Purpose

The deletion task of a user now includes a marking phase where user infos are stored in the Mork database before being deleted from edX.

Also refactored the edX deletion task into a new file, with a status check before deletion, and a status update after.
