### PR TITLE
✨(tasks) add limit parameter to bulk deletion and warning tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 - Flag users for deletion in Mork database when deletion process begins
 - Add status verification checks before and after user deletion in edX
 - Add support for emailing a single user via api
+- Add an optional `limit` parameter for bulk deletion and warning tasks
 
 ## Changed
 

--- a/src/app/mork/api/v1/routers/tasks.py
+++ b/src/app/mork/api/v1/routers/tasks.py
@@ -33,7 +33,7 @@ async def create_task(
 ) -> TaskResponse:
     """Create a new task."""
     celery_task = TASK_TYPE_TO_FUNC[task.type]
-    celery_params = task.model_dump(exclude="type")
+    celery_params = task.model_dump(exclude="type", exclude_none=True)
 
     result = celery_task.delay(**celery_params)
 

--- a/src/app/mork/schemas/tasks.py
+++ b/src/app/mork/schemas/tasks.py
@@ -3,7 +3,7 @@
 from enum import Enum, unique
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr, PositiveInt
 
 from mork.celery.tasks.deletion import delete_inactive_users, delete_user
 from mork.celery.tasks.emailing import warn_inactive_users, warn_user
@@ -43,12 +43,14 @@ class DeleteInactiveUsers(TaskCreateBase):
     """Model for creating a task to delete all inactive users."""
 
     type: Literal[TaskType.DELETE_INACTIVE_USERS]
+    limit: PositiveInt | None = None
 
 
 class EmailInactiveUsers(TaskCreateBase):
     """Model for creating a task to email all inactive users."""
 
     type: Literal[TaskType.EMAIL_INACTIVE_USERS]
+    limit: PositiveInt | None = None
 
 
 class DeleteUser(TaskCreateBase):

--- a/src/app/mork/tests/api/v1/routers/test_tasks.py
+++ b/src/app/mork/tests/api/v1/routers/test_tasks.py
@@ -21,6 +21,7 @@ async def test_tasks_auth(http_client: AsyncClient):
     "body_params",
     [
         {"type": "email_inactive_users", "dry_run": False},
+        {"type": "email_inactive_users", "limit": 100, "dry_run": False},
         {
             "type": "email_user",
             "email": "johndoe@example.com",
@@ -28,6 +29,7 @@ async def test_tasks_auth(http_client: AsyncClient):
             "dry_run": False,
         },
         {"type": "delete_inactive_users", "dry_run": False},
+        {"type": "delete_inactive_users", "limit": 100, "dry_run": False},
         {"type": "delete_user", "email": "johndoe@example.com", "dry_run": False},
         {"type": "email_inactive_users", "dry_run": True},
         {


### PR DESCRIPTION
## Purpose

Currently, the tasks `delete_inactive_users` and `warn_inactive_users` process all inactive users in a single run. This "all-or-nothing" approach makes it difficult to validate results on smaller subsets

## Proposal

Add optional limit parameter to bulk deletion and warning tasks to allow for gradual processing of large user sets when needed.
