### PR TITLE
🐛(api) ensure API status updates are committed to database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 ### Fixed
 
 - Correct email templates path in Dockerfile
+- Ensure API status updates are committed to database
 
 ## [0.4.0] - 2024-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - Add edx mongodb task to anonymize personal data from edx forums
 - Add Sentry configuration for Celery
 
+### Changed
+
+- Improve task status endpoint path to `tasks/task_id/status`
+
 ### Fixed
 
 - Correct email templates path in Dockerfile

--- a/src/app/mork/api/v1/routers/tasks.py
+++ b/src/app/mork/api/v1/routers/tasks.py
@@ -52,7 +52,7 @@ async def get_available_tasks(response: Response) -> dict:
     return {"task_types": list(TaskType)}
 
 
-@router.get("/status/{task_id}")
+@router.get("/{task_id}/status")
 async def get_task_status(task_id: str) -> TaskResponse:
     """Get the task status for `task_id`."""
     status = AsyncResult(task_id).state

--- a/src/app/mork/api/v1/routers/users.py
+++ b/src/app/mork/api/v1/routers/users.py
@@ -164,6 +164,8 @@ async def update_user_status(
             status_code=status.HTTP_404_NOT_FOUND, detail=message
         ) from exc
 
+    session.commit()
+
     response_user = UserStatusUpdate(
         id=updated.user_id,
         service_name=updated.service_name,

--- a/src/app/mork/tests/api/v1/routers/test_tasks.py
+++ b/src/app/mork/tests/api/v1/routers/test_tasks.py
@@ -13,7 +13,7 @@ async def test_tasks_auth(http_client: AsyncClient):
     # see https://github.com/tiangolo/fastapi/discussions/9130
     assert (await http_client.post("/v1/tasks/")).status_code == 403
     assert (await http_client.options("/v1/tasks/")).status_code == 403
-    assert (await http_client.get("/v1/tasks/status/1234")).status_code == 403
+    assert (await http_client.get("/v1/tasks/1234/status")).status_code == 403
 
 
 @pytest.mark.anyio
@@ -66,7 +66,7 @@ async def test_create_task(
         assert response_data.get("id")
         assert response_data.get("status") == "PENDING"
         assert (
-            response.headers["location"] == f"/tasks/status/{response_data.get("id")}"
+            response.headers["location"] == f"/tasks/{response_data.get("id")}/status"
         )
 
         expected_params = {
@@ -159,7 +159,7 @@ async def test_get_task_status(http_client: AsyncClient, auth_headers: dict):
 
     with patch("mork.api.v1.tasks.AsyncResult", celery_result):
         response = await http_client.get(
-            f"/v1/tasks/status/{task_id}",
+            f"/v1/tasks/{task_id}/status",
             headers=auth_headers,
         )
         response_data = response.json()


### PR DESCRIPTION
## Purpose

HTTP patch to users status endpoint has no impact on the user.
The update endpoint is not persisting changes to the database.

## Proposal

Adding session commit so the status update is persisted.
As we are only testing inside a same session, and we are avoiding any commit in the test suite, test remains the same.

On a side note, improving the task status endpoint path from `tasks/status/task_id` to `tasks/task_id/status`
