### PR TITLE
🔧(dockerfile) correct email template path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - Add edx mongodb task to anonymize personal data from edx forums
 - Add Sentry configuration for Celery
 
+### Fixed
+
+- Correct email templates path in Dockerfile
+
 ## [0.4.0] - 2024-11-20
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ ARG DOCKER_USER=1000
 USER ${DOCKER_USER}
 
 # Copy mork mails
-COPY --from=mail-builder /mail/app/mork/templates /app/src/app/mork/templates
+COPY --from=mail-builder /mail/app/mork/templates /app/mork/templates
 
 CMD ["uvicorn", \
      "mork.api:app", \


### PR DESCRIPTION
## Purpose

When trying to send a warning email on preprod, email templates are not found.

## Proposal

Changes template copy path from '/app/src/app/mork/templates' to
'/app/mork/templates', ensuring that email templates are correctly loaded by
the Jinja2 template engine during task execution.
