### PR TITLE
🔖(helm) bump release to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.5.1] - 2024-11-26
+
 ### Fixed
 
 - Fix missing component label in Celery deployment
@@ -78,7 +80,8 @@ and this project adheres to
 - Add celery task to warn inactive users by email
 - Add celery task to delete inactive users from edx database
 
-[unreleased]: https://github.com/openfun/mork/compare/v0.5.0...main
+[unreleased]: https://github.com/openfun/mork/compare/v0.5.1...main
+[0.5.1]: https://github.com/openfun/mork/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/openfun/mork/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/openfun/mork/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/openfun/mork/compare/v0.2.0...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix missing component label in Celery deployment
+
 ## [0.5.0] - 2024-11-25
 
 ### Added

--- a/src/helm/mork/Chart.yaml
+++ b/src/helm/mork/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: mork
 description: Mork, to warn and manage FUN inactive users 
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "0.5.0"

--- a/src/helm/mork/templates/celery/deployment.yaml
+++ b/src/helm/mork/templates/celery/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        app.kubernetes.io/component: celery
         {{- include "mork.labels" . | nindent 8 }}
     spec:
       {{- include "mork.imagePullSecrets" . | nindent 6 }}


### PR DESCRIPTION
## Purpose

Celery deployment selectors labels have been narrowed, but the Celery deployment
spec metadata is missing the celery component label.


## Proposal

Adding the missing component label and releasing a patch. 
