### PR TITLE
🔇(sentry) filter emails and username from sentry events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,6 @@ and this project adheres to
 
 ## [Unreleased]
 
-## [0.5.1] - 2024-11-26
-
-### Fixed
-
-- Fix missing component label in Celery deployment
-
 ## [0.5.0] - 2024-11-25
 
 ### Added
@@ -80,8 +74,7 @@ and this project adheres to
 - Add celery task to warn inactive users by email
 - Add celery task to delete inactive users from edx database
 
-[unreleased]: https://github.com/openfun/mork/compare/v0.5.1...main
-[0.5.1]: https://github.com/openfun/mork/compare/v0.5.0...v0.5.1
+[unreleased]: https://github.com/openfun/mork/compare/v0.5.0...main
 [0.5.0]: https://github.com/openfun/mork/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/openfun/mork/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/openfun/mork/compare/v0.2.0...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Scrub `email` and `username` fields from logs and exceptions sent to Sentry
+
 ## [0.5.0] - 2024-11-25
 
 ### Added

--- a/src/app/mork/celery/celery_app.py
+++ b/src/app/mork/celery/celery_app.py
@@ -2,6 +2,7 @@
 
 import sentry_sdk
 from celery import Celery, signals
+from sentry_sdk.scrubber import DEFAULT_PII_DENYLIST, EventScrubber
 
 from mork import __version__
 from mork.conf import settings
@@ -20,6 +21,7 @@ app = Celery(
 def init_sentry(**_kwargs):
     """Initialize Sentry SDK on Celery startup."""
     if settings.SENTRY_DSN is not None:
+        pii_denylist = DEFAULT_PII_DENYLIST + ["email", "username"]
         sentry_sdk.init(
             dsn=settings.SENTRY_DSN,
             enable_tracing=True,
@@ -27,6 +29,8 @@ def init_sentry(**_kwargs):
             release=__version__,
             environment=settings.SENTRY_EXECUTION_ENVIRONMENT,
             max_breadcrumbs=50,
+            send_default_pii=False,
+            event_scrubber=EventScrubber(pii_denylist=pii_denylist),
         )
         sentry_sdk.set_tag("application", "celery")
 

--- a/src/app/mork/celery/tasks/emailing.py
+++ b/src/app/mork/celery/tasks/emailing.py
@@ -11,7 +11,7 @@ from mork.conf import settings
 from mork.db import MorkDB
 from mork.edx.mysql import crud
 from mork.edx.mysql.database import OpenEdxMySQLDB
-from mork.exceptions import EmailAlreadySent, EmailSendError
+from mork.exceptions import EmailSendError
 from mork.mail import send_email
 from mork.models.tasks import EmailStatus
 
@@ -55,13 +55,14 @@ def warn_user(self, email: str, username: str, dry_run: bool = True):
     """Celery task that warns the specified user by sending an email."""
     # Check that user has not already received a warning email
     if check_email_already_sent(email):
-        raise EmailAlreadySent("An email has already been sent to this user")
-
-    if dry_run:
-        logger.info(f"Dry run: An email would have been sent to user with {email=} ")
+        logger.warning("An email has already been sent to this user")
         return
 
-    logger.info(f"Sending an email to user with {email=}")
+    if dry_run:
+        logger.info("Dry run: An email would have been sent")
+        return
+
+    logger.debug(f"Sending an email to user with {email=}")
     try:
         send_email(email, username)
     except EmailSendError as exc:

--- a/src/app/mork/edx/mongo/crud.py
+++ b/src/app/mork/edx/mongo/crud.py
@@ -37,6 +37,6 @@ def anonymize_comments(username: str) -> int:
         anonymous=True,
     )
 
-    logger.info(f"Anonymized {comment_count} comment(s) for user {username}")
+    logger.info(f"Anonymized {comment_count} comment(s)")
 
     return comment_count

--- a/src/app/mork/edx/mysql/crud.py
+++ b/src/app/mork/edx/mysql/crud.py
@@ -121,13 +121,13 @@ def delete_user(session: Session, email: str) -> None:
     """
     user_to_delete = session.scalar(select(AuthUser).where(AuthUser.email == email))
     if not user_to_delete:
-        msg = f"User with {email=} does not exist"
-        logger.error(msg)
+        msg = "User does not exist"
+        logger.warning(msg)
         raise UserNotFound(msg)
 
     if _has_protected_children(session, user_to_delete.id):
-        msg = f"User with {email=} is linked to a protected table and cannot be deleted"
-        logger.error(msg)
+        msg = "User is linked to a protected table and cannot be deleted"
+        logger.warning(msg)
         raise UserProtected(msg)
 
     # Delete entries in student_courseenrollmentallowed table containing user email

--- a/src/app/mork/exceptions.py
+++ b/src/app/mork/exceptions.py
@@ -1,10 +1,6 @@
 """Exceptions for Mork."""
 
 
-class EmailAlreadySent(Exception):
-    """Raised when an email has already been sent to this user."""
-
-
 class EmailSendError(Exception):
     """Raised when an error occurs when sending an email."""
 

--- a/src/app/mork/tests/celery/tasks/test_deletion.py
+++ b/src/app/mork/tests/celery/tasks/test_deletion.py
@@ -292,7 +292,7 @@ def test_mark_user_for_deletion(edx_mysql_db, db_session, caplog, monkeypatch):
     assert (
         "mork.celery.tasks.deletion",
         logging.INFO,
-        f"User with email='{inserted_user.email}' is already marked for deletion",
+        "User is already marked for deletion",
     ) in caplog.record_tuples
 
     # Reset factory persistence
@@ -379,7 +379,7 @@ def test_remove_email_status_no_entry(caplog, db_session, monkeypatch):
     assert (
         "mork.celery.tasks.deletion",
         logging.WARNING,
-        "Email status - No user found with email johndoe1@example.com for deletion",
+        "Email status not found",
     ) in caplog.record_tuples
 
 
@@ -407,5 +407,5 @@ def test_remove_email_status_with_failure(caplog, db_session, monkeypatch):
     assert (
         "mork.celery.tasks.deletion",
         logging.ERROR,
-        "Email status - Failed to delete user with email johndoe1@example.com",
+        "Failed to delete email status",
     ) in caplog.record_tuples

--- a/src/app/mork/tests/celery/tasks/test_edx.py
+++ b/src/app/mork/tests/celery/tasks/test_edx.py
@@ -121,11 +121,7 @@ def test_delete_edx_platform_user_invalid_status(db_session, monkeypatch):
         "mork.celery.tasks.edx.update_status_in_mork", mock_update_status_in_mork
     )
 
-    with pytest.raises(
-        UserStatusError,
-        match=f"User {str(user.id)} is not to be deleted. Status: DeletionStatus.DELETED",  # noqa: E501
-    ):
-        delete_edx_platform_user(user.id)
+    delete_edx_platform_user(user.id)
 
     mock_delete_edx_mysql_user.assert_not_called()
     mock_delete_edx_mongo_user.assert_not_called()
@@ -188,7 +184,7 @@ def test_delete_edx_platform_user_failed_status_update(db_session, monkeypatch):
 
     with pytest.raises(
         UserStatusError,
-        match=f"Failed to update deletion status to deleted for user {user.id}",
+        match=f"Failed to update deletion status to 'deleted' for user {user.id}",
     ):
         delete_edx_platform_user(user.id)
 
@@ -316,6 +312,6 @@ def test_delete_edx_mongo_user_with_failure(edx_mongo_db, monkeypatch):
 
     with pytest.raises(
         UserDeleteError,
-        match=f"Failed to delete comments of user {username} : An error occurred",
+        match="Failed to delete comments: An error occurred",
     ):
         delete_edx_mongo_user(username=username)

--- a/src/app/mork/tests/celery/tasks/test_emailing.py
+++ b/src/app/mork/tests/celery/tasks/test_emailing.py
@@ -13,7 +13,7 @@ from mork.celery.tasks.emailing import (
 )
 from mork.conf import settings
 from mork.edx.mysql.factories.auth import EdxAuthUserFactory
-from mork.exceptions import EmailAlreadySent, EmailSendError
+from mork.exceptions import EmailSendError
 from mork.factories.tasks import EmailStatusFactory
 
 
@@ -237,10 +237,12 @@ def test_warn_user_already_sent(monkeypatch):
         "mork.celery.tasks.emailing.check_email_already_sent", lambda x: True
     )
 
-    with pytest.raises(
-        EmailAlreadySent, match="An email has already been sent to this user"
-    ):
-        warn_user("johndoe@example.com", "JohnDoe")
+    mock_send_email = Mock()
+    monkeypatch.setattr("mork.celery.tasks.emailing.send_email", mock_send_email)
+
+    warn_user("johndoe@example.com", "JohnDoe")
+
+    mock_send_email.assert_not_called()
 
 
 def test_warn_user_sending_failure(monkeypatch):

--- a/src/app/mork/tests/edx/mysql/test_crud.py
+++ b/src/app/mork/tests/edx/mysql/test_crud.py
@@ -158,7 +158,7 @@ def test_edx_crud_delete_user_missing(edx_mysql_db):
 
     email = "john_doe@example.com"
 
-    with pytest.raises(UserNotFound, match=f"User with {email=} does not exist"):
+    with pytest.raises(UserNotFound, match="User does not exist"):
         crud.delete_user(edx_mysql_db.session, email=email)
 
 
@@ -246,7 +246,7 @@ def test_edx_crud_delete_user_protected_table(edx_mysql_db):
 
     with pytest.raises(
         UserProtected,
-        match=f"User with {email=} is linked to a protected table and cannot be deleted",  # noqa: E501
+        match="User is linked to a protected table and cannot be deleted",
     ):
         crud.delete_user(edx_mysql_db.session, email=email)
 

--- a/src/helm/CHANGELOG.md
+++ b/src/helm/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.5.1] - 2024-11-26
+
+### Fixed
+
+- Fix missing component label in Celery deployment
+
 ## [0.5.0] - 2024-11-25
 
 ### Added
@@ -58,6 +64,7 @@ and this project adheres to
 - Implement base Helm chart
 
 [unreleased]: https://github.com/openfun/mork/tree/main/src/helm
+[0.5.1]: https://github.com/openfun/mork/releases/tag/helm/v0.5.1
 [0.5.0]: https://github.com/openfun/mork/releases/tag/helm/v0.5.0
 [0.4.0]: https://github.com/openfun/mork/releases/tag/helm/v0.4.0
 [0.3.0]: https://github.com/openfun/mork/releases/tag/helm/v0.3.0


### PR DESCRIPTION
## Purpose

Some PII are sent to Sentry.

## Proposal

- Filtering out `email` and `username` fields using the SDK event scrubber.
- Removing PII from logs and exceptions

_On a side note, fixing a CHANGELOG mistake by relocating an entry from the Mork changelog to the Helm changelog._