### PR TITLE
🔒️(edx) map and add wiki tables to protected tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Add and protect `wiki_article` and `wiki_articlerevision` tables
+
 ### Fixed
 
 - Scrub `email` and `username` fields from logs and exceptions sent to Sentry

--- a/src/app/mork/edx/mysql/crud.py
+++ b/src/app/mork/edx/mysql/crud.py
@@ -21,6 +21,7 @@ from mork.edx.mysql.models.dark import DarkLangDarklangconfig
 from mork.edx.mysql.models.student import StudentCourseenrollmentallowed
 from mork.edx.mysql.models.util import UtilRatelimitconfiguration
 from mork.edx.mysql.models.verify import VerifyStudentHistoricalverificationdeadline
+from mork.edx.mysql.models.wiki import WikiArticle, WikiArticlerevision
 from mork.exceptions import UserNotFound, UserProtected
 
 logger = getLogger(__name__)
@@ -105,6 +106,8 @@ def _has_protected_children(session: Session, user_id) -> bool:
         select(1).where(
             VerifyStudentHistoricalverificationdeadline.history_user_id == user_id
         ),
+        select(1).where(WikiArticle.owner_id == user_id),
+        select(1).where(WikiArticlerevision.user_id == user_id),
     )
 
     # Execute the union query and check if any results exist

--- a/src/app/mork/edx/mysql/factories/auth.py
+++ b/src/app/mork/edx/mysql/factories/auth.py
@@ -51,6 +51,7 @@ from .verify import (
     EdxVerifyStudentHistoricalverificationdeadlineFactory,
     EdxVerifyStudentSoftwaresecurephotoverificationFactory,
 )
+from .wiki import WikiArticleFactory, WikiArticlerevisionFactory
 
 
 class EdxAuthRegistrationFactory(BaseSQLAlchemyModelFactory):
@@ -186,6 +187,18 @@ class EdxAuthUserFactory(BaseSQLAlchemyModelFactory):
                 "history_user",
                 size=3,
                 history_user_id=factory.SelfAttribute("..id"),
+            ),
+            wiki_article=factory.RelatedFactoryList(
+                WikiArticleFactory,
+                "owner",
+                size=3,
+                owner_id=factory.SelfAttribute("..id"),
+            ),
+            wiki_articlerevision=factory.RelatedFactoryList(
+                WikiArticlerevisionFactory,
+                "user",
+                size=3,
+                user_id=factory.SelfAttribute("..id"),
             ),
         )
 

--- a/src/app/mork/edx/mysql/factories/wiki.py
+++ b/src/app/mork/edx/mysql/factories/wiki.py
@@ -1,0 +1,51 @@
+"""Factory classes for verify models."""
+
+import factory
+
+from mork.edx.mysql.models.wiki import WikiArticle, WikiArticlerevision
+
+from .base import BaseSQLAlchemyModelFactory
+
+
+class WikiArticleFactory(BaseSQLAlchemyModelFactory):
+    """Factory for the `wiki_article` table."""
+
+    class Meta:
+        """Factory configuration."""
+
+        model = WikiArticle
+
+    id = factory.Sequence(lambda n: n + 1)
+    current_revision_id = factory.Sequence(lambda n: n + 1)
+    created = factory.Faker("date_time")
+    modified = factory.Faker("date_time")
+    owner_id = factory.Sequence(lambda n: n + 1)
+    group_id = factory.Sequence(lambda n: n + 1)
+    group_read = factory.Faker("random_int", min=0, max=1)
+    group_write = factory.Faker("random_int", min=0, max=1)
+    other_read = factory.Faker("random_int", min=0, max=1)
+    other_write = factory.Faker("random_int", min=0, max=1)
+
+
+class WikiArticlerevisionFactory(BaseSQLAlchemyModelFactory):
+    """Factory for the `wiki_articlerevision` table."""
+
+    class Meta:
+        """Factory configuration."""
+
+        model = WikiArticlerevision
+
+    id = factory.Sequence(lambda n: n + 1)
+    revision_number = factory.Sequence(lambda n: n + 1)
+    user_message = factory.Faker("text")
+    automatic_log = factory.Faker("text")
+    ip_address = ""
+    user_id = factory.Sequence(lambda n: n + 1)
+    modified = factory.Faker("date_time")
+    created = factory.Faker("date_time")
+    previous_revision_id = factory.Sequence(lambda n: n + 1)
+    deleted = factory.Faker("random_int", min=0, max=1)
+    locked = factory.Faker("random_int", min=0, max=1)
+    article_id = factory.Sequence(lambda n: n + 1)
+    content = factory.Faker("text", max_nb_chars=2000)
+    title = factory.Faker("sentence")

--- a/src/app/mork/edx/mysql/models/auth.py
+++ b/src/app/mork/edx/mysql/models/auth.py
@@ -48,6 +48,7 @@ from .verify import (
     VerifyStudentHistoricalverificationdeadline,
     VerifyStudentSoftwaresecurephotoverification,
 )
+from .wiki import WikiArticle, WikiArticlerevision
 
 
 class AuthUser(Base):
@@ -311,6 +312,16 @@ class AuthUser(Base):
         "VerifyStudentSoftwaresecurephotoverification",
         foreign_keys=[VerifyStudentSoftwaresecurephotoverification.user_id],
         primaryjoin="VerifyStudentSoftwaresecurephotoverification.user_id == AuthUser.id",  # noqa: E501
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    wiki_article: Mapped[List["WikiArticle"]] = relationship(
+        "WikiArticle",
+        back_populates="owner",
+        cascade="all, delete-orphan",
+    )
+    wiki_articlerevision: Mapped[List["WikiArticlerevision"]] = relationship(
+        "WikiArticlerevision",
         back_populates="user",
         cascade="all, delete-orphan",
     )

--- a/src/app/mork/edx/mysql/models/wiki.py
+++ b/src/app/mork/edx/mysql/models/wiki.py
@@ -1,0 +1,72 @@
+"""Mork edx wiki models."""
+
+import datetime
+
+from sqlalchemy import DateTime, ForeignKeyConstraint, Index, String
+from sqlalchemy.dialects.mysql import INTEGER, TEXT
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+
+class WikiArticle(Base):
+    """Model for the `wiki_article` table."""
+
+    __tablename__ = "wiki_article"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["owner_id"],
+            ["auth_user.id"],
+        ),
+    )
+    id: Mapped[int] = mapped_column(INTEGER(11), primary_key=True)
+    current_revision_id: Mapped[int] = mapped_column(INTEGER(11), unique=True)
+    created: Mapped[datetime.datetime] = mapped_column(DateTime, nullable=False)
+    modified: Mapped[datetime.datetime] = mapped_column(DateTime, nullable=False)
+    owner_id: Mapped[int] = mapped_column(INTEGER(11), index=True)
+    group_id: Mapped[int] = mapped_column(INTEGER(11), index=True)
+    group_read: Mapped[int] = mapped_column(INTEGER(1), nullable=False)
+    group_write: Mapped[int] = mapped_column(INTEGER(1), nullable=False)
+    other_read: Mapped[int] = mapped_column(INTEGER(1), nullable=False)
+    other_write: Mapped[int] = mapped_column(INTEGER(1), nullable=False)
+
+    owner: Mapped["AuthUser"] = relationship(  # noqa: F821
+        "AuthUser", back_populates="wiki_article"
+    )
+
+
+class WikiArticlerevision(Base):
+    """Model for the `wiki_articlerevision` table."""
+
+    __tablename__ = "wiki_articlerevision"
+    __table_args__ = (
+        Index(
+            "wiki_articlerevision_article_id_4b4e7910c8e7b2d0_uniq",
+            "article_id",
+            "revision_number",
+            unique=True,
+        ),
+        ForeignKeyConstraint(
+            ["user_id"],
+            ["auth_user.id"],
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(INTEGER(11), primary_key=True)
+    revision_number: Mapped[int] = mapped_column(INTEGER(11), nullable=False)
+    user_message: Mapped[str] = mapped_column(TEXT, nullable=False)
+    automatic_log: Mapped[str] = mapped_column(TEXT, nullable=False)
+    ip_address: Mapped[str] = mapped_column(String(15))
+    user_id: Mapped[int] = mapped_column(INTEGER(11), index=True)
+    modified: Mapped[datetime.datetime] = mapped_column(DateTime, nullable=False)
+    created: Mapped[datetime.datetime] = mapped_column(DateTime, nullable=False)
+    previous_revision_id: Mapped[int] = mapped_column(INTEGER(11), index=True)
+    deleted: Mapped[int] = mapped_column(INTEGER(1), nullable=False)
+    locked: Mapped[int] = mapped_column(INTEGER(1), nullable=False)
+    article_id: Mapped[int] = mapped_column(INTEGER(11), nullable=False, index=True)
+    content: Mapped[str] = mapped_column(TEXT, nullable=False)
+    title: Mapped[str] = mapped_column(String(512), nullable=False)
+
+    user: Mapped["AuthUser"] = relationship(  # noqa: F821
+        "AuthUser", back_populates="wiki_articlerevision"
+    )

--- a/src/app/mork/tests/edx/mysql/test_crud.py
+++ b/src/app/mork/tests/edx/mysql/test_crud.py
@@ -238,6 +238,8 @@ def test_edx_crud_delete_user_protected_table(edx_mysql_db):
         "dark_lang_darklangconfig",
         "util_ratelimitconfiguration",
         "verify_student_historicalverificationdeadline",
+        "wiki_article",
+        "wiki_articlerevision",
     ]
 
     for table_name in protected_tables:


### PR DESCRIPTION
## Purpose

The `wiki_article` and `wiki_articlerevision` tables references users through foreign key.
An error is raised when attempting to delete a user that owns a wiki article or a wiki article revision.

## Proposal
As we don't want entries from these tables to be removed, mapping them and adding them to the protected tables list.
