### PR TITLE
✨(api) add created_at and updated_at to user response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - Add and protect `wiki_article` and `wiki_articlerevision` tables
+- Add `created_at` and `updated_at` fields to response from user API
 
 ### Fixed
 

--- a/src/app/mork/schemas/users.py
+++ b/src/app/mork/schemas/users.py
@@ -1,5 +1,6 @@
 """Mork users schemas."""
 
+from datetime import datetime
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, EmailStr
@@ -27,6 +28,8 @@ class UserRead(BaseModel):
     email: EmailStr
     reason: DeletionReason
     service_statuses: list[UserServiceStatusRead]
+    created_at: datetime
+    updated_at: datetime
 
 
 class UserStatusRead(BaseModel):

--- a/src/app/mork/tests/api/v1/routers/test_users.py
+++ b/src/app/mork/tests/api/v1/routers/test_users.py
@@ -3,6 +3,7 @@
 from uuid import uuid4
 
 import pytest
+from faker import Faker
 from httpx import AsyncClient
 from sqlalchemy import func, select
 
@@ -245,8 +246,10 @@ async def test_user_read(db_session, http_client: AsyncClient, auth_headers: dic
     UserServiceStatusFactory._meta.sqlalchemy_session = db_session
     UserFactory._meta.sqlalchemy_session = db_session
 
+    creation_date = Faker().date_time()
+
     # Create one user that needs to be deleted on all services
-    user = UserFactory.create()
+    user = UserFactory.create(created_at=creation_date, updated_at=creation_date)
 
     # Get id of newly created user
     user_id = db_session.scalar(select(User.id))
@@ -280,6 +283,8 @@ async def test_user_read(db_session, http_client: AsyncClient, auth_headers: dic
                 "status": "to_delete",
             },
         ],
+        "created_at": creation_date.isoformat(),
+        "updated_at": creation_date.isoformat(),
     }
 
 


### PR DESCRIPTION
## Purpose

Response from the user API is missing the `created_at` and `updated_at` datetimes.
Adding them.
