### PR TITLE
🥅(celery) catch DBAPI errors from the database driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 ### Fixed
 
 - Scrub `email` and `username` fields from logs and exceptions sent to Sentry
+- Catch errors from the database driver
 
 ## [0.5.0] - 2024-11-25
 

--- a/src/app/mork/celery/tasks/edx.py
+++ b/src/app/mork/celery/tasks/edx.py
@@ -4,7 +4,7 @@ from logging import getLogger
 from uuid import UUID
 
 from mongoengine.errors import OperationError
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import DBAPIError, SQLAlchemyError
 
 from mork.celery.celery_app import app
 from mork.celery.utils import (
@@ -95,7 +95,7 @@ def delete_edx_mysql_user(email: str):
         db.session.rollback()
         db.session.close()
         raise
-    except SQLAlchemyError as exc:
+    except (SQLAlchemyError, DBAPIError) as exc:
         db.session.rollback()
         msg = "Failed to delete user from edX MySQL"
         logger.error(msg)


### PR DESCRIPTION
## Purpose

Extend error handling to capture DBAPI errors from the database driver (raised when losing connection to the database for example) and not just SQLAlchemy exceptions.
