### PR TITLE
🩺(celery) add custom liveness and readiness probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - Add and protect `wiki_article` and `wiki_articlerevision` tables
 - Add `created_at` and `updated_at` fields to response from user API
+- Add custom liveness and readiness probe for Celery
 
 ### Fixed
 

--- a/src/app/mork/celery/celery_app.py
+++ b/src/app/mork/celery/celery_app.py
@@ -7,6 +7,8 @@ from sentry_sdk.scrubber import DEFAULT_PII_DENYLIST, EventScrubber
 from mork import __version__
 from mork.conf import settings
 
+from .probe import LivenessProbe
+
 app = Celery(
     "mork",
     include=[
@@ -15,6 +17,7 @@ app = Celery(
         "mork.celery.tasks.emailing",
     ],
 )
+app.steps["worker"].add(LivenessProbe)
 
 
 @signals.celeryd_init.connect

--- a/src/app/mork/celery/probe.py
+++ b/src/app/mork/celery/probe.py
@@ -1,0 +1,50 @@
+"""Mork Celery custom liveness and readiness probes."""
+
+from pathlib import Path
+
+from celery import bootsteps
+from celery.signals import worker_ready, worker_shutdown
+
+HEARTBEAT_FILE = Path("/tmp/worker_heartbeat")  # noqa: S108
+READINESS_FILE = Path("/tmp/worker_ready")  # noqa: S108
+
+
+class LivenessProbe(bootsteps.StartStopStep):
+    """Celery worker component that implements a liveness probe mechanism."""
+
+    requires = {"celery.worker.components:Timer"}
+
+    def __init__(self, worker, **kwargs):  # noqa: ARG002
+        """Initialize the liveness probe."""
+        self.requests = []
+        self.tref = None
+
+    def start(self, worker):
+        """Start the liveness probe with a periodic heartbeat."""
+        # Touch the heartbeat file every second
+        self.tref = worker.timer.call_repeatedly(
+            1.0,
+            self.update_heartbeat_file,
+            (worker,),
+            priority=10,
+        )
+
+    def stop(self, worker):  # noqa: ARG002
+        """Stop the liveness probe by removing the heartbeat file."""
+        HEARTBEAT_FILE.unlink(missing_ok=True)
+
+    def update_heartbeat_file(self, worker):  # noqa: ARG002
+        """Update the heartbeat file by touching it."""
+        HEARTBEAT_FILE.touch()
+
+
+@worker_ready.connect
+def worker_ready(**_):
+    """Signal handler that creates a readiness file when the worker is ready."""
+    READINESS_FILE.touch()
+
+
+@worker_shutdown.connect
+def worker_shutdown(**_):
+    """Signal handler that removes the readiness file when the worker shuts down."""
+    READINESS_FILE.unlink(missing_ok=True)

--- a/src/helm/CHANGELOG.md
+++ b/src/helm/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Change Celery liveness and readiness probes to file-based probes
+
 ## [0.5.1] - 2024-11-26
 
 ### Fixed

--- a/src/helm/mork/templates/celery/deployment.yaml
+++ b/src/helm/mork/templates/celery/deployment.yaml
@@ -36,10 +36,10 @@ spec:
               command:
               - "bash"
               - "-c"
-              - "celery -A mork.celery.celery_app inspect ping -d mork@$HOSTNAME"
+              - "find /tmp/worker_heartbeat -mmin -1 | grep ."
             failureThreshold: 3
-            initialDelaySeconds: 60
-            periodSeconds: 30
+            initialDelaySeconds: 30
+            periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
           readinessProbe:
@@ -47,9 +47,9 @@ spec:
               command:
               - "bash"                                                                           
               - "-c"                                                                                  
-              - "celery -A mork.celery.celery_app inspect ping -d mork@$HOSTNAME"
+              - "test -e /tmp/worker_ready"
             failureThreshold: 3
-            initialDelaySeconds: 15
+            initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5


### PR DESCRIPTION
## Purpose

Under heavy load (when deleting a lot of inactive users), the Celery liveness and readiness probes, based on the command `celery -A project inspect ping` uses a lot of CPU and is hanging before failing, resulting in a restart of the Celery worker pod.

## Proposal

To solve this, greatly inspired by https://github.com/celery/celery/issues/4079#issuecomment-1128954283 , adding:
- a custom liveness probe mechanism which periodically updates a local temporary file,
- a custom readiness probe mechanism which creates/deletes another local temporary file.
