### PR TITLE
🔇(sentry) filter contact URLs in breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove user email from Brevo request breadcrumb before sending to Sentry
+
 ## [0.6.0] - 2024-12-02
 
 ### Added


### PR DESCRIPTION
## Proposal

Adding a before_send handler to filter out contact email from Brevo URLs in
breadcrumbs.
