### PR TITLE
🚩(brevo) disable brevo deletion on empty Brevo API URL setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Disable Brevo request on empty Brevo API URL setting
+
 ### Fixed
 
 - Remove user email from Brevo request breadcrumb before sending to Sentry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Changed
 
 - Disable Brevo request on empty Brevo API URL setting
+- Activate recursive scrubbing of Sentry events
 
 ### Fixed
 

--- a/src/app/mork/celery/celery_app.py
+++ b/src/app/mork/celery/celery_app.py
@@ -50,7 +50,7 @@ def init_sentry(**_kwargs):
             environment=settings.SENTRY_EXECUTION_ENVIRONMENT,
             max_breadcrumbs=50,
             send_default_pii=False,
-            event_scrubber=EventScrubber(pii_denylist=pii_denylist),
+            event_scrubber=EventScrubber(pii_denylist=pii_denylist, recursive=True),
             before_send=before_send,
         )
         sentry_sdk.set_tag("application", "celery")

--- a/src/app/mork/celery/tasks/brevo.py
+++ b/src/app/mork/celery/tasks/brevo.py
@@ -28,6 +28,10 @@ logger = getLogger(__name__)
 )
 def delete_brevo_platform_user(self, user_id: UUID):
     """Task to delete user from the Brevo platform."""
+    if not settings.BREVO_API_URL:
+        logger.info("Brevo API URL not set, skipping deletion.")
+        return
+
     user = get_user_from_mork(user_id)
     if not user:
         msg = f"User {user_id} could not be retrieved from Mork"

--- a/src/app/mork/tests/celery/tasks/test_brevo.py
+++ b/src/app/mork/tests/celery/tasks/test_brevo.py
@@ -1,6 +1,7 @@
 """Tests for Mork Celery Brevo tasks."""
 
 import logging
+import uuid
 from unittest.mock import Mock
 from uuid import uuid4
 
@@ -52,6 +53,21 @@ def test_delete_brevo_platform_user(db_session, monkeypatch):
     mock_update_status_in_mork.assert_called_once_with(
         user_id=user.id, service=ServiceName.BREVO, status=DeletionStatus.DELETED
     )
+
+
+def test_delete_brevo_platform_user_empty_setting(db_session, monkeypatch):
+    """Test to delete user from Brevo platform when the API URL is not set."""
+
+    monkeypatch.setattr("mork.celery.tasks.brevo.settings.BREVO_API_URL", "")
+
+    mock_delete_brevo_user = Mock()
+    monkeypatch.setattr(
+        "mork.celery.tasks.brevo.delete_brevo_user", mock_delete_brevo_user
+    )
+
+    delete_brevo_platform_user(uuid.uuid4())
+
+    mock_delete_brevo_user.assert_not_called()
 
 
 def test_delete_brevo_platform_user_invalid_user(monkeypatch):


### PR DESCRIPTION
## Purpose

- As we don't want to spam the Brevo API when deleting users on preprod, adding a mean to disable the requests when setting an empty Brevo API URL.
- Some PII are still sent to Sentry, under extra.celery-job.args or kwargs. The Sentry SDK event scrubber does not scrub recursively by default. Activating recursive scrubbing to avoid sending emails and usernames to Sentry.
