### PR TITLE
🐛(project) fix ascii encoding issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix ASCII encoding issue for email containing non-ASCII characters
+
 ## [0.7.0] - 2024-12-16
 
 ### Changed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - "3306:3306"
     env_file: 
       - .env
-    command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
+    command: mysqld --character-set-server=latin1 --collation-server=latin1_swedish_ci
 
   mongo:
     image: mongo:3.0.15

--- a/src/app/mork/conf.py
+++ b/src/app/mork/conf.py
@@ -119,7 +119,7 @@ class Settings(BaseSettings):
         return (
             f"{self.DB_ENGINE}://"
             f"{self.DB_USER}:{self.DB_PASSWORD}@"
-            f"{self.DB_HOST}/{self.DB_NAME}"
+            f"{self.DB_HOST}/{self.DB_NAME}?client_encoding=utf-8"
         )
 
     @property
@@ -128,7 +128,7 @@ class Settings(BaseSettings):
         return (
             f"{self.DB_ENGINE}://"
             f"{self.DB_USER}:{self.DB_PASSWORD}@"
-            f"{self.DB_HOST}/{self.TEST_DB_NAME}"
+            f"{self.DB_HOST}/{self.TEST_DB_NAME}?client_encoding=utf-8"
         )
 
     @property


### PR DESCRIPTION
## Purpose

When querying the PostgreSQL database with an email containing a non-ASCII character, a UnicodeEncodeError is raised. It seems the SQLAlchemy connection to the postgres db force encoding the string into ASCII.
To avoid this error, set the client encoding to utf8 in the connection URI.

Fixes #98 