### PR TITLE
🦺(project) remove email validation for emails coming from edx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - Fix ASCII encoding issue for email containing non-ASCII characters
 
+### Removed
+
+- Remove email validation for emails coming from edx
+
 ## [0.7.0] - 2024-12-16
 
 ### Changed

--- a/src/app/mork/schemas/tasks.py
+++ b/src/app/mork/schemas/tasks.py
@@ -57,7 +57,7 @@ class DeleteUser(TaskCreateBase):
     """Model for creating a task to delete one user."""
 
     type: Literal[TaskType.DELETE_USER]
-    email: EmailStr
+    email: str
 
 
 class EmailUser(TaskCreateBase):

--- a/src/app/mork/schemas/users.py
+++ b/src/app/mork/schemas/users.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, EmailStr
+from pydantic import BaseModel, ConfigDict
 
 from mork.models.users import DeletionReason, DeletionStatus, ServiceName
 
@@ -25,7 +25,7 @@ class UserRead(BaseModel):
     id: UUID
     username: str
     edx_user_id: int
-    email: EmailStr
+    email: str
     reason: DeletionReason
     service_statuses: list[UserServiceStatusRead]
     created_at: datetime

--- a/src/app/mork/tests/api/v1/routers/test_tasks.py
+++ b/src/app/mork/tests/api/v1/routers/test_tasks.py
@@ -31,6 +31,7 @@ async def test_tasks_auth(http_client: AsyncClient):
         {"type": "delete_inactive_users", "dry_run": False},
         {"type": "delete_inactive_users", "limit": 100, "dry_run": False},
         {"type": "delete_user", "email": "johndoe@example.com", "dry_run": False},
+        {"type": "delete_user", "email": "johndoe@wrong.email.", "dry_run": False},
         {"type": "email_inactive_users", "dry_run": True},
         {
             "type": "email_user",
@@ -66,7 +67,7 @@ async def test_create_task(
         assert response_data.get("id")
         assert response_data.get("status") == "PENDING"
         assert (
-            response.headers["location"] == f"/tasks/{response_data.get("id")}/status"
+            response.headers["location"] == f"/tasks/{response_data.get('id')}/status"
         )
 
         expected_params = {


### PR DESCRIPTION
## Purpose

A validation error UserDeleteError is raised when trying to delete a user with
an incorrect email address, e.g. finishing with a '.'
Mork should not validate emails coming from edx, and should delete the user
anyway.

## Proposal

Removing pydantic `EmailStr` validation on `UserRead` model and `DeleteUser`
task class.

Fixes #103
