### PR TITLE
🐛(edx) fix auth_user_groups and student_manualenrollmentaudit relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - Fix ASCII encoding issue for email containing non-ASCII characters
 - Fix edX `auth_user_groups` relation 
+- Fix edX `studebt_manualenrollmentaudit` relation
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Fixed
 
 - Fix ASCII encoding issue for email containing non-ASCII characters
+- Fix edX `auth_user_groups` relation 
 
 ### Removed
 

--- a/src/app/mork/edx/mysql/factories/auth.py
+++ b/src/app/mork/edx/mysql/factories/auth.py
@@ -42,6 +42,7 @@ from .student import (
     EdxStudentHistoricalcourseenrollmentFactory,
     EdxStudentLanguageproficiencyFactory,
     EdxStudentLoginfailureFactory,
+    EdxStudentManualenrollmentauditFactory,
     EdxStudentPendingemailchangeFactory,
     EdxStudentUserstandingFactory,
 )
@@ -350,6 +351,12 @@ class EdxAuthUserFactory(BaseSQLAlchemyModelFactory):
         "user",
         size=3,
         user_id=factory.SelfAttribute("..id"),
+    )
+    student_manualenrollmentaudit = factory.RelatedFactoryList(
+        EdxStudentManualenrollmentauditFactory,
+        "enrolled_by",
+        size=3,
+        enrolled_by_id=factory.SelfAttribute("..id"),
     )
     student_pendingemailchange = factory.RelatedFactory(
         EdxStudentPendingemailchangeFactory, user_id=factory.SelfAttribute("..id")

--- a/src/app/mork/edx/mysql/factories/auth.py
+++ b/src/app/mork/edx/mysql/factories/auth.py
@@ -220,8 +220,11 @@ class EdxAuthUserFactory(BaseSQLAlchemyModelFactory):
     auth_userprofile = factory.RelatedFactory(
         EdxAuthUserprofileFactory, user_id=factory.SelfAttribute("..id")
     )
-    auth_user_groups = factory.RelatedFactory(
-        EdxAuthUserGroupsFactory, user_id=factory.SelfAttribute("..id")
+    auth_user_groups = factory.RelatedFactoryList(
+        EdxAuthUserGroupsFactory,
+        "user",
+        size=3,
+        user_id=factory.SelfAttribute("..id"),
     )
     bulk_email_courseemail = factory.RelatedFactoryList(
         EdxBulkEmailCourseemailFactory,

--- a/src/app/mork/edx/mysql/models/auth.py
+++ b/src/app/mork/edx/mysql/models/auth.py
@@ -39,6 +39,7 @@ from .student import (
     StudentHistoricalcourseenrollment,
     StudentLanguageproficiency,
     StudentLoginfailure,
+    StudentManualenrollmentaudit,
     StudentPendingemailchange,
     StudentUserstanding,
 )
@@ -258,6 +259,12 @@ class AuthUser(Base):
         "StudentLoginfailure",
         back_populates="user",
         cascade="all, delete-orphan",
+    )
+    student_manualenrollmentaudit: Mapped[List["StudentManualenrollmentaudit"]] = (
+        relationship(
+            "StudentManualenrollmentaudit",
+            back_populates="enrolled_by",
+        )
     )
     student_pendingemailchange: Mapped["StudentPendingemailchange"] = relationship(
         "StudentPendingemailchange",

--- a/src/app/mork/edx/mysql/models/auth.py
+++ b/src/app/mork/edx/mysql/models/auth.py
@@ -87,7 +87,7 @@ class AuthUser(Base):
         back_populates="user",
         cascade="all, delete-orphan",
     )
-    auth_user_groups: Mapped["AuthUserGroups"] = relationship(
+    auth_user_groups: Mapped[List["AuthUserGroups"]] = relationship(
         "AuthUserGroups",
         back_populates="user",
         cascade="all, delete-orphan",

--- a/src/app/mork/edx/mysql/models/student.py
+++ b/src/app/mork/edx/mysql/models/student.py
@@ -261,7 +261,7 @@ class StudentManualenrollmentaudit(Base):
 
     id: Mapped[int] = mapped_column(INTEGER(11), primary_key=True)
     enrollment_id: Mapped[int] = mapped_column(INTEGER(11), index=True)
-    enrolled_by_id: Mapped[int] = mapped_column(INTEGER(11), index=True)
+    enrolled_by_id: Mapped[int] = mapped_column(INTEGER(11), nullable=True, index=True)
     enrolled_email: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     time_stamp: Mapped[datetime.datetime] = mapped_column(DateTime)
     state_transition: Mapped[str] = mapped_column(String(255), nullable=False)
@@ -269,6 +269,9 @@ class StudentManualenrollmentaudit(Base):
 
     enrollment: Mapped["StudentCourseenrollment"] = relationship(
         "StudentCourseenrollment", back_populates="student_manualenrollmentaudit"
+    )
+    enrolled_by: Mapped["AuthUser"] = relationship(  # noqa: F821
+        "AuthUser", back_populates="student_manualenrollmentaudit"
     )
 
 


### PR DESCRIPTION
## Purpose

- Deleting a user from edx MySQL that has an entry in the `auth_user_groups` table returns an `IntegrityError`.
- Deleting a user from edx MySQL that has is an enroller in the `student_manualenrollmentaudit` table (field `enrolled_by_id`) returns an `IntegrityError`.

## Proposal

- The `auth_user_groups` relation was incorrectly set to a one-to-one relationship instead of a many-to-one relationship. Fixing it. Fixes #97
- The relation for field `enrolled_by_id` was missing. Adding the relation, and since we don't want to delete entries from this table, and as the `enrolled_by_id` is nullable in the database, we do not specify a cascade behavior. As a result, the field is set to NULL by SQLAlchemy. Fixes #96

