### PR TITLE
🐛(sarbacane) fix incorrect status code check when deleting user contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix incorrect status code check when deleting user contact
+
 ## [0.9.0] - 2025-03-17
 
 ### Changed

--- a/src/app/mork/celery/tasks/sarbacane.py
+++ b/src/app/mork/celery/tasks/sarbacane.py
@@ -99,7 +99,8 @@ def _delete_contact(client: httpx.Client, endpoint: str, email: str):
         response = client.delete(f"{endpoint}?email={email}")
         response.raise_for_status()
     except httpx.HTTPStatusError as exc:
-        if exc.response.status_code == httpx.codes.NOT_FOUND:
+        data = exc.response.json() if exc.response.content else {}
+        if data.get("message") == "No contacts versions to delete":
             logger.info(f"User not found at {endpoint}")
         else:
             msg = f"Failed to delete user contact at {endpoint}"

--- a/src/app/mork/tests/celery/tasks/test_sarbacane.py
+++ b/src/app/mork/tests/celery/tasks/test_sarbacane.py
@@ -249,7 +249,8 @@ def test_delete_sarbacane_user(httpx_mock):
         url=f"{settings.SARBACANE_API_URL}/lists/list0/contacts?email={email}",
         method="DELETE",
         headers=headers,
-        status_code=404,
+        status_code=500,
+        json={"message": "No contacts versions to delete"},
     )
     httpx_mock.add_response(
         url=f"{settings.SARBACANE_API_URL}/lists/list1/contacts?email={email}",
@@ -270,7 +271,8 @@ def test_delete_sarbacane_user(httpx_mock):
         url=f"{settings.SARBACANE_API_URL}/blacklists/blacklist0/unsubscribers?email={email}",
         method="DELETE",
         headers=headers,
-        status_code=404,
+        status_code=500,
+        json={"message": "No contacts versions to delete"},
     )
     httpx_mock.add_response(
         url=f"{settings.SARBACANE_API_URL}/blacklists/blacklist1/unsubscribers?email={email}",
@@ -357,7 +359,8 @@ def test_delete_sarbacane_user_not_found(httpx_mock, caplog):
         url=f"{settings.SARBACANE_API_URL}/lists/list0/contacts?email={email}",
         method="DELETE",
         headers=headers,
-        status_code=404,
+        status_code=500,
+        json={"message": "No contacts versions to delete"},
     )
 
     # Mock requests on /blacklists endpoint
@@ -366,7 +369,7 @@ def test_delete_sarbacane_user_not_found(httpx_mock, caplog):
         method="GET",
         headers=headers,
         status_code=200,
-        json=[],
+        json={},
     )
 
     # Make sure no error is raised if contact not found on Sarbacane


### PR DESCRIPTION
## Purpose

We were expecting a 404 Not Found when trying to delete a contact that is not
present in a list, but Sarbacane returns a 500 Internal Server Error.
